### PR TITLE
Update serverless scheduler for qa event

### DIFF
--- a/example/serverless.yml
+++ b/example/serverless.yml
@@ -26,5 +26,4 @@ functions:
     environment:
       IOPIPE_TOKEN: ${env:IOPIPE_TOKEN}
     events:
-      - schedule:
-          rate: rate(5 minutes)
+      - schedule: rate(5 minutes)


### PR DESCRIPTION
Updates schedule for erroring event (throws runtime error because no input found)