### PR TITLE
Profiler update for jwtAccess Tokens

### DIFF
--- a/src/main/java/com/iopipe/IOpipeConstants.java
+++ b/src/main/java/com/iopipe/IOpipeConstants.java
@@ -83,7 +83,7 @@ public interface IOpipeConstants
 	public static String defaultProfilerUrl()
 	{
 		return "https://signer." + IOpipeConstants.chosenRegion() +
-			".iopipe.com/?extension=.zip";
+			".iopipe.com/";
 	}
 	
 	/**

--- a/src/main/java/com/iopipe/IOpipeMeasurement.java
+++ b/src/main/java/com/iopipe/IOpipeMeasurement.java
@@ -40,15 +40,19 @@ public final class IOpipeMeasurement
 			System.getProperty("os.name", "unknown")) == 0;
 
 	/** The configuration. */
+	@Deprecated
 	protected final IOpipeConfiguration config;
 
 	/** The context this is taking the measurement for. */
+	@Deprecated
 	protected final Context context;
 	
 	/** The service which initialized this class. */
+	@Deprecated
 	protected final IOpipeService service;
 	
 	/** The start execution time. */
+	@Deprecated
 	protected final long starttime;
 	
 	/**
@@ -81,6 +85,7 @@ public final class IOpipeMeasurement
 	 * @throws NullPointerException On null arguments.
 	 * @since 2017/12/17
 	 */
+	@Deprecated
 	IOpipeMeasurement(IOpipeConfiguration __config, Context __context,
 		IOpipeService __sv, long __now)
 		throws NullPointerException
@@ -177,6 +182,7 @@ public final class IOpipeMeasurement
 	 * @throws RemoteException If the request could not be built.
 	 * @since 2017/12/17
 	 */
+	@Deprecated
 	public RemoteRequest buildRequest()
 		throws RemoteException
 	{

--- a/src/main/java/com/iopipe/IOpipeMeasurement.java
+++ b/src/main/java/com/iopipe/IOpipeMeasurement.java
@@ -23,6 +23,8 @@ import java.util.Set;
 import java.util.TreeSet;
 import javax.json.Json;
 import javax.json.JsonException;
+import javax.json.JsonObject;
+import javax.json.JsonValue;
 import javax.json.stream.JsonGenerator;
 
 /**

--- a/src/main/java/com/iopipe/IOpipeService.java
+++ b/src/main/java/com/iopipe/IOpipeService.java
@@ -201,8 +201,7 @@ public final class IOpipeService
 		
 		// Setup execution information
 		long nowtime = System.currentTimeMillis();
-		IOpipeMeasurement measurement = new IOpipeMeasurement(config,
-			__context, this, nowtime);
+		IOpipeMeasurement measurement = new IOpipeMeasurement();
 		IOpipeExecution exec = new IOpipeExecution(this, config, __context,
 			measurement, threadgroup, nowtime);
 		
@@ -289,7 +288,7 @@ public final class IOpipeService
 		
 		// Generate and send result to server
 		if (watchdog == null || !watchdog._generated.getAndSet(true))
-			this.__sendRequest(measurement.buildRequest());
+			this.__sendRequest(exec.__buildRequest());
 		
 		// Throw the called exception as if the wrapper did not have any
 		// trouble

--- a/src/main/java/com/iopipe/__TimeOutWatchDog__.java
+++ b/src/main/java/com/iopipe/__TimeOutWatchDog__.java
@@ -155,9 +155,9 @@ final class __TimeOutWatchDog__
 				reported.setStackTrace(sourcethread.getStackTrace());
 				
 				// Send report to the service
-				IOpipeMeasurement measurement = this.execution.measurement();
-				measurement.__setThrown(reported);
-				this.service.__sendRequest(measurement.buildRequest());
+				IOpipeExecution exec = this.execution;
+				exec.measurement().__setThrown(reported);
+				this.service.__sendRequest(exec.__buildRequest());
 				
 				// Do not need to execute anymore
 				return;

--- a/src/main/java/com/iopipe/plugin/IOpipePluginExecution.java
+++ b/src/main/java/com/iopipe/plugin/IOpipePluginExecution.java
@@ -1,5 +1,7 @@
 package com.iopipe.plugin;
 
+import javax.json.JsonObject;
+
 /**
  * For plugins which provide access to information based on execution, this
  * interface is used as a base for those plugins to provide functionality that
@@ -9,5 +11,18 @@ package com.iopipe.plugin;
  */
 public interface IOpipePluginExecution
 {
+	/**
+	 * Plugins may add additional details to be reported, this allows the
+	 * plugin to specify fields which will be added to the plugin information.
+	 *
+	 * @return An object containing the key and value pairs to be added to
+	 * the plugin report, if the return value is {@code null} then nothing is
+	 * used.
+	 * @since 2018/03/15
+	 */
+	public default JsonObject extraReport()
+	{
+		return null;
+	}
 }
 

--- a/src/main/java/com/iopipe/plugin/profiler/ProfilerExecution.java
+++ b/src/main/java/com/iopipe/plugin/profiler/ProfilerExecution.java
@@ -123,6 +123,25 @@ public class ProfilerExecution
 	}
 	
 	/**
+	 * {@inheritDoc}
+	 * @since 2018/03/15
+	 */
+	@Override
+	public JsonObject extraReport()
+	{
+		// If no access token was specified then just ignore it
+		String jwtaccesstoken = this._jwtaccesstoken;
+		if (jwtaccesstoken == null)
+			return null;
+		
+		// Otherwise build object
+		return Json.createObjectBuilder().add("uploads",
+			Json.createArrayBuilder().
+				add(jwtaccesstoken).
+			build()).build();
+	}
+	
+	/**
 	 * Post execution.
 	 *
 	 * @since 2018/02/09
@@ -291,6 +310,7 @@ public class ProfilerExecution
 				gen.write("arn", context.getInvokedFunctionArn());
 				gen.write("requestId", context.getAwsRequestId());
 				gen.write("timestamp", execution.startTimestamp());
+				gen.write("extension", ".zip");
 				
 				// Finished
 				gen.writeEnd();


### PR DESCRIPTION
This is an update to the profiler so that it can report jwtAccess tokens.

This is currently in progress.

There is going to be an incompatible change which will be performed in the `IOpipeMeasurement` class and that will be the removal of `buildRequest()`. That method should not have been in that class and it should not have been public anyway, the class should just store some measurement information and such accordingly, not perform much more work on building requests. This should have no impact at all because there is really no need for the user to build requests when that is automatically done by the service.