### PR TITLE
Report total, used, and free memory in bytes instead of KiB.

### DIFF
--- a/src/main/java/com/iopipe/IOpipeExecution.java
+++ b/src/main/java/com/iopipe/IOpipeExecution.java
@@ -497,8 +497,8 @@ public final class IOpipeExecution
 
 			long totalmem, freemem;
 			gen.write("hostname", SystemMeasurement.HOSTNAME);
-			gen.write("totalmem", (totalmem = sysinfo.memorytotalkib));
-			gen.write("freemem", (freemem = sysinfo.memoryfreekib));
+			gen.write("totalmem", (totalmem = sysinfo.memorytotalbytes));
+			gen.write("freemem", (freemem = sysinfo.memoryfreebytes));
 			gen.write("usedmem", totalmem - freemem);
 
 			// Start CPUs

--- a/src/main/java/com/iopipe/SystemMeasurement.java
+++ b/src/main/java/com/iopipe/SystemMeasurement.java
@@ -28,8 +28,14 @@ public final class SystemMeasurement
 	/** The file descriptor count. */
 	public final int fdsize;
 	
+	/** Total amount of memory in bytes. */
+	public final long memorytotalbytes;
+	
 	/** Total amount of memory in KiB. */
 	public final int memorytotalkib;
+	
+	/** Free amount of memory in bytes. */
+	public final long memoryfreebytes;
 	
 	/** Free amount of memory in KiB. */
 	public final int memoryfreekib;
@@ -67,10 +73,15 @@ public final class SystemMeasurement
 	{
 		// Memory information
 		Map<String, String> meminfo = __readMap(Paths.get("/proc/meminfo"));
-		this.memorytotalkib = __readInt(
-			meminfo.getOrDefault("MemTotal", "0"));
-		this.memoryfreekib = __readInt(
-			meminfo.getOrDefault("MemFree", "0"));
+		int mtkib, mfkib;
+		this.memorytotalkib = (mtkib = __readInt(
+			meminfo.getOrDefault("MemTotal", "0")));
+		this.memoryfreekib = (mfkib = __readInt(
+			meminfo.getOrDefault("MemFree", "0")));
+		
+		// Memory information is in KiB, so just multiply the values for now
+		this.memorytotalbytes = mtkib * 1024L;
+		this.memoryfreebytes = mfkib * 1024L;
 		
 		// Obtain CPU information
 		List<Cpu> cpus = new ArrayList<>(


### PR DESCRIPTION
This uses bytes instead of KiB for the os.environment fields, specifically `totalmem`, `freemem`, and `usedmem`.

This fixes issue #56.
