### PR TITLE
Emit warning when custom metric value is too long and do not send in the report. (Fixes #58)

### DIFF
--- a/src/main/java/com/iopipe/IOpipeConstants.java
+++ b/src/main/java/com/iopipe/IOpipeConstants.java
@@ -48,9 +48,13 @@ public interface IOpipeConstants
 	public static final String DEFAULT_PROFILER_URL =
 		IOpipeConstants.defaultProfilerUrl();
 	
-	/** The length limit for how long custom metric names and labels. */
+	/** The length limit for how long custom metric and label names may be. */
 	public static final int NAME_CODEPOINT_LIMIT =
 		128;
+	
+	/** The length limit for how long custom metric values may be. */
+	public static final int VALUE_CODEPOINT_LIMIT =
+		1024;
 	
 	/**
 	 * Returns the default region which has been chosen to send events and

--- a/src/main/java/com/iopipe/IOpipeExecution.java
+++ b/src/main/java/com/iopipe/IOpipeExecution.java
@@ -615,26 +615,44 @@ public final class IOpipeExecution
 			{
 				CustomMetric metric = custmetrics[i];
 				
+				// Check that the name is in the limit
 				String xname = metric.name();
-				if (IOpipeExecution.__isNameInLimit(xname))
+				if (!IOpipeExecution.__isNameInLimit(xname))
 				{
-					gen.writeStartObject();
-					
-					gen.write("name", xname);
-					
-					if (metric.hasString())
-						gen.write("s", metric.stringValue());
-					if (metric.hasLong())
-						gen.write("n", metric.longValue());
-					
-					gen.writeEnd();
-				}
-				
-				// Emit warning
-				else
 					_LOGGER.warn("Metric exceeds the {} codepoint limit and " +
 						"will not be reported: {}",
 						IOpipeConstants.NAME_CODEPOINT_LIMIT, xname);
+					continue;
+				}
+				
+				// Check if the value is in range
+				String svalue;
+				if (metric.hasString())
+				{
+					svalue = metric.stringValue();
+					
+					if (!IOpipeExecution.__isValueInLimit(svalue))
+					{
+						_LOGGER.warn("Metric value exceeds the {} codepoint " +
+							"limit and will not be reported: {}",
+							IOpipeConstants.VALUE_CODEPOINT_LIMIT, xname);
+						continue;
+					}	
+				}
+				else
+					svalue = null;
+				
+				// Write data
+				gen.writeStartObject();
+				
+				gen.write("name", xname);
+				
+				if (svalue != null)
+					gen.write("s", svalue);
+				if (metric.hasLong())
+					gen.write("n", metric.longValue());
+				
+				gen.writeEnd();
 			}
 			
 			// End of metrics
@@ -768,6 +786,25 @@ public final class IOpipeExecution
 		
 		return __s.codePointCount(0, __s.length()) <
 			IOpipeConstants.NAME_CODEPOINT_LIMIT;
+	}
+	
+	/**
+	 * Checks if the given string is within the value limit before it is
+	 * reported.
+	 *
+	 * @param __s The name to check.
+	 * @return If the name is short enough to be included.
+	 * @throws NullPointerException On null arguments.
+	 * @since 2018/05/03
+	 */
+	private static final boolean __isValueInLimit(String __s)
+		throws NullPointerException
+	{
+		if (__s == null)
+			throw new NullPointerException();
+		
+		return __s.codePointCount(0, __s.length()) <
+			IOpipeConstants.VALUE_CODEPOINT_LIMIT;
 	}
 }
 

--- a/src/main/java/com/iopipe/IOpipeExecution.java
+++ b/src/main/java/com/iopipe/IOpipeExecution.java
@@ -619,8 +619,8 @@ public final class IOpipeExecution
 				String xname = metric.name();
 				if (!IOpipeExecution.__isNameInLimit(xname))
 				{
-					_LOGGER.warn("Metric exceeds the {} codepoint limit and " +
-						"will not be reported: {}",
+					_LOGGER.warn("Metric name exceeds the {} codepoint " +
+						"length limit and will not be reported: {}",
 						IOpipeConstants.NAME_CODEPOINT_LIMIT, xname);
 					continue;
 				}
@@ -634,7 +634,7 @@ public final class IOpipeExecution
 					if (!IOpipeExecution.__isValueInLimit(svalue))
 					{
 						_LOGGER.warn("Metric value exceeds the {} codepoint " +
-							"limit and will not be reported: {}",
+							"length limit and will not be reported: {}",
 							IOpipeConstants.VALUE_CODEPOINT_LIMIT, xname);
 						continue;
 					}	

--- a/src/test/java/com/iopipe/Engine.java
+++ b/src/test/java/com/iopipe/Engine.java
@@ -51,6 +51,7 @@ public abstract class Engine
 			(__e) -> new __DoLabel__(__e, false, String.join("",
 				Collections.nCopies(IOpipeConstants.NAME_CODEPOINT_LIMIT + 32,
 				"a"))),
+			__DoLongValueCustomMetric__::new,
 			__DoLongNameCustomMetric__::new,
 		};
 	

--- a/src/test/java/com/iopipe/__DoLongValueCustomMetric__.java
+++ b/src/test/java/com/iopipe/__DoLongValueCustomMetric__.java
@@ -1,0 +1,103 @@
+package com.iopipe;
+
+import com.iopipe.http.RemoteRequest;
+import com.iopipe.http.RemoteResult;
+import com.iopipe.IOpipeMeasurement;
+import java.util.Collections;
+import java.util.Map;
+import javax.json.JsonString;
+import javax.json.JsonNumber;
+import javax.json.JsonValue;
+
+/**
+ * Ensures that custom metrics which really long values are not added.
+ *
+ * @since 2018/04/11
+ */
+class __DoLongValueCustomMetric__
+	extends Single
+{
+	/** Sent with no exception? */
+	protected final BooleanValue noerror =
+		new BooleanValue("noerror");
+		
+	/** Got a result from the server okay? */
+	protected final BooleanValue remoterecvokay =
+		new BooleanValue("remoterecvokay");
+	
+	/** Is there a custom string? */
+	protected final BooleanValue hascustomstring =
+		new BooleanValue("hascustomstring");
+	
+	/**
+	 * Constructs the test.
+	 *
+	 * @param __e The owning engine.
+	 * @since 2018/04/11
+	 */
+	__DoLongValueCustomMetric__(Engine __e)
+	{
+		super(__e, "longcustommetricvalue");
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * @since 2018/04/11
+	 */
+	@Override
+	public void end()
+	{
+		super.assertTrue(this.remoterecvokay);
+		super.assertTrue(this.noerror);
+		
+		super.assertFalse(this.hascustomstring);
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * @since 2018/04/11
+	 */
+	@Override
+	public void remoteRequest(WrappedRequest __r)
+	{
+		Map<String, JsonValue> expand = __Utils__.expandObject(__r.request);
+		
+		// It is invalid if there is an error
+		if (null == __Utils__.hasError(expand))
+			this.noerror.set(true);
+		
+		for (int i = 0; i < 2; i++)
+		{
+			JsonValue sv = expand.get(".custom_metrics[" + i + "].s");
+			
+			if (sv != null)
+				this.hascustomstring.set(true);
+		}
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * @since 2018/04/11
+	 */
+	@Override
+	public void remoteResult(WrappedResult __r)
+	{
+		if (__Utils__.isResultOkay(__r.result))
+			this.remoterecvokay.set(true);
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * @since 2018/04/11
+	 */
+	@Override
+	public void run(IOpipeExecution __e)
+		throws Throwable
+	{
+		IOpipeMeasurement m = __e.measurement();
+		
+		m.customMetric("long", String.join("", Collections.nCopies(
+			IOpipeConstants.VALUE_CODEPOINT_LIMIT + 32, "a")));
+	}
+}
+

--- a/src/test/java/com/iopipe/__DoLongValueCustomMetric__.java
+++ b/src/test/java/com/iopipe/__DoLongValueCustomMetric__.java
@@ -12,7 +12,7 @@ import javax.json.JsonValue;
 /**
  * Ensures that custom metrics which really long values are not added.
  *
- * @since 2018/04/11
+ * @since 2018/05/03
  */
 class __DoLongValueCustomMetric__
 	extends Single
@@ -33,7 +33,7 @@ class __DoLongValueCustomMetric__
 	 * Constructs the test.
 	 *
 	 * @param __e The owning engine.
-	 * @since 2018/04/11
+	 * @since 2018/05/03
 	 */
 	__DoLongValueCustomMetric__(Engine __e)
 	{
@@ -42,7 +42,7 @@ class __DoLongValueCustomMetric__
 	
 	/**
 	 * {@inheritDoc}
-	 * @since 2018/04/11
+	 * @since 2018/05/03
 	 */
 	@Override
 	public void end()
@@ -55,7 +55,7 @@ class __DoLongValueCustomMetric__
 	
 	/**
 	 * {@inheritDoc}
-	 * @since 2018/04/11
+	 * @since 2018/05/03
 	 */
 	@Override
 	public void remoteRequest(WrappedRequest __r)
@@ -77,7 +77,7 @@ class __DoLongValueCustomMetric__
 	
 	/**
 	 * {@inheritDoc}
-	 * @since 2018/04/11
+	 * @since 2018/05/03
 	 */
 	@Override
 	public void remoteResult(WrappedResult __r)
@@ -88,7 +88,7 @@ class __DoLongValueCustomMetric__
 	
 	/**
 	 * {@inheritDoc}
-	 * @since 2018/04/11
+	 * @since 2018/05/03
 	 */
 	@Override
 	public void run(IOpipeExecution __e)


### PR DESCRIPTION
Do not send very long custom metric values in the report and instead warn when they are sent.

Fixes #58 