### PR TITLE
Use version 1.2.0 for the profiler and trace plugin.

### DIFF
--- a/src/main/java/com/iopipe/plugin/profiler/ProfilerPlugin.java
+++ b/src/main/java/com/iopipe/plugin/profiler/ProfilerPlugin.java
@@ -103,7 +103,7 @@ public class ProfilerPlugin
 	@Override
 	public String version()
 	{
-		return IOpipeConstants.AGENT_VERSION;
+		return "1.2.0";
 	}
 }
 

--- a/src/main/java/com/iopipe/plugin/trace/TracePlugin.java
+++ b/src/main/java/com/iopipe/plugin/trace/TracePlugin.java
@@ -75,7 +75,7 @@ public class TracePlugin
 	@Override
 	public String version()
 	{
-		return IOpipeConstants.AGENT_VERSION;
+		return "1.2.0";
 	}
 }
 


### PR DESCRIPTION
This sets the version for the trace and profiler plugins to use 1.2.0 instead of matching the agent version.