### PR TITLE
Change plugins being enabling environment variable to match the Python agent (_ENABLED), fixes #64.

### DIFF
--- a/PROFILER.md
+++ b/PROFILER.md
@@ -13,11 +13,11 @@ long as the profiler is enabled.
 
 ## Enabling Profiling
 
-Set the environment variable IOPIPE_PROFILER_ENABLE to `true`
+Set the environment variable IOPIPE_PROFILER_ENABLED to `true`
 
 ### For Serverless Framework:
 
-In the `serverless.yml` file, under `functions:`, `(your_function_name_here):`, `environment:`, set the environment variable `IOPIPE_PROFILER_ENABLE` to `true`
+In the `serverless.yml` file, under `functions:`, `(your_function_name_here):`, `environment:`, set the environment variable `IOPIPE_PROFILER_ENABLED` to `true`
 
 ## Customizing Profiling
 

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ take precedence when available.
     the client.
   * If you need help looking for your token you can visit:
     [Find your project token](https://dashboard.iopipe.com/install).
- * `com.iopipe.plugin.<name>` or `IOPIPE_<NAME>_ENABLE`
+ * `com.iopipe.plugin.<name>` or `IOPIPE_<NAME>_ENABLED`
    * If set to `true` then the specified plugin will be enabled.
    * If set to `false` then the plugin will be disabled.
    * If this is not set for a plugin then it will use the setting from the
@@ -268,7 +268,7 @@ If the plugin is not enabled then the measurement will not record anything.
 Disabling the plugin can be done as followed:
 
  * Setting the system property `com.iopipe.plugin.trace` to `false`.
- * Setting the environment variable `IOPIPE_TRACE_ENABLE` to `false`.
+ * Setting the environment variable `IOPIPE_TRACE_ENABLED` to `false`.
 
 # Building and Installing the Project Locally
 

--- a/src/main/java/com/iopipe/IOpipeConfiguration.java
+++ b/src/main/java/com/iopipe/IOpipeConfiguration.java
@@ -89,7 +89,7 @@ public final class IOpipeConfiguration
 	
 	/** Environment variable suffix for plugin state. */
 	private static final String _ENVIRONMENT_PLUGIN_SUFFIX =
-		"_ENABLE";
+		"_ENABLED";
 	
 	/** The disabled configuration. */
 	public static final IOpipeConfiguration DISABLED_CONFIG;


### PR DESCRIPTION
This matches the Python agent and uses `_ENABLED` for the suffix for environment variables that enable or disable plugins.