### PR TITLE
Correct JavaDoc tags for 1.4.0

### DIFF
--- a/src/main/java/com/iopipe/SystemMeasurement.java
+++ b/src/main/java/com/iopipe/SystemMeasurement.java
@@ -98,6 +98,7 @@ public final class SystemMeasurement
 	 * Measures disk usage at the given path.
 	 *
 	 * @param __p The path to measure.
+	 * @return The disk usage for the given path.
 	 * @throws NullPointerException On null arguments.
 	 * @since 2018/05/17
 	 */

--- a/src/main/java/com/iopipe/plugin/profiler/ThreadStatistics.java
+++ b/src/main/java/com/iopipe/plugin/profiler/ThreadStatistics.java
@@ -92,7 +92,7 @@ public final class ThreadStatistics
 	 * Creates snapshots of all the threads which exist.
 	 *
 	 * @return The statistics on all running threads.
-	 * @sincd 2018/05/24
+	 * @since 2018/05/24
 	 */
 	public static ThreadStatistics[] snapshots()
 	{
@@ -105,7 +105,7 @@ public final class ThreadStatistics
 	 *
 	 * @param __bean The bean to get thread information from.
 	 * @return The statistics on all running threads.
-	 * @sincd 2018/05/24
+	 * @since 2018/05/24
 	 */
 	public static ThreadStatistics[] snapshots(ThreadMXBean __bean)
 	{

--- a/src/main/java/com/iopipe/plugin/profiler/TrackedThread.java
+++ b/src/main/java/com/iopipe/plugin/profiler/TrackedThread.java
@@ -54,6 +54,7 @@ public final class TrackedThread
 	 *
 	 * @param __thread The thread to record information for.
 	 * @param __ldx Logical thread index.
+	 * @param __m The owning method tracker.
 	 * @throws NullPointerException On null arguments.
 	 * @since 2018/02/19
 	 */


### PR DESCRIPTION
This corrects the JavaDoc tags for 1.4.0.