### PR TITLE
Remove the extra -SNAPSHOT, fixes #93.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.iopipe</groupId>
   <artifactId>iopipe</artifactId>
-  <version>1.4.0</version>
+  <version>1.5.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>${project.groupId}:${project.artifactId}</name>
   <url>https://www.iopipe.com/</url>


### PR DESCRIPTION
An extra `-SNAPSHOT` has appeared in the POM, this removes it since it is not valid.