### PR TITLE
Document how to access the context and use better wording (Fixes #21).

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,8 +172,8 @@ service.<String>run(context, (exec) -> "Hello World!", input);
 
 ### Accessing the AWS `Context` Object
 
-The AWS `Context` object may be obtained by invoking `context()` on the
-method parameter that is the `IOpipeExecution` instance. For example:
+The AWS `Context` object may be obtained by invoking `context()` on
+the `IOpipeExecution` instance. For example:
 
 ```java
 protected final String wrappedHandleRequest(IOpipeExecution __exec, String __n)

--- a/README.md
+++ b/README.md
@@ -170,6 +170,22 @@ service.<String>run(context, (exec) -> "Hello World!");
 service.<String>run(context, (exec) -> "Hello World!", input);
 ```
 
+### Accessing the AWS `Context` Object
+
+The AWS `Context` object may be obtained by invoking `context()` on the
+method parameter that is the `IOpipeExecution` instance. For example:
+
+```java
+protected final String wrappedHandleRequest(IOpipeExecution __exec, String __n)
+{
+    // Code here...
+    
+    Context context = __exec.context();
+    
+    // Code here...
+}
+```
+
 ### Setting system properties and environment variables
 
 Set up IOpipe using system properties or environment variables. N.B., it is necessary

--- a/src/main/java/com/iopipe/IOpipeExecution.java
+++ b/src/main/java/com/iopipe/IOpipeExecution.java
@@ -34,6 +34,9 @@ import org.apache.logging.log4j.LogManager;
  * Each execution will have a unique instance of this object and as such will
  * be initialized when it is first used.
  *
+ * The {@link com.amazonaws.services.lambda.runtime.Context} object can be
+ * obtained by invoking the {@link #context()} method.
+ *
  * @since 2018/01/19
  */
 public final class IOpipeExecution
@@ -121,7 +124,8 @@ public final class IOpipeExecution
 	}
 	
 	/**
-	 * Returns the AWS context.
+	 * Returns the context for the Amazon Web Service Lambda execution that
+	 * is currently running.
 	 *
 	 * @return The AWS context.
 	 * @since 2018/01/19

--- a/src/main/java/com/iopipe/SimpleRequestHandlerWrapper.java
+++ b/src/main/java/com/iopipe/SimpleRequestHandlerWrapper.java
@@ -20,7 +20,10 @@ public abstract class SimpleRequestHandlerWrapper<I, O>
 	 * This method is implemented by sub-classes and is used as the actual
 	 * entry point for lambdas.
 	 *
-	 * @param __exec The execution information.
+	 * @param __exec The instance for the current lambda execution. The
+	 * {@link com.amazonaws.services.lambda.runtime.Context} object can be
+	 * obtained by invoking the {@link IOpipeExecution#context()} method on
+	 * the {@code __exec} parameter.
 	 * @param __input The input value.
 	 * @return The return value.
 	 * @since 2017/12/18

--- a/src/main/java/com/iopipe/SimpleRequestStreamHandlerWrapper.java
+++ b/src/main/java/com/iopipe/SimpleRequestStreamHandlerWrapper.java
@@ -21,7 +21,10 @@ public abstract class SimpleRequestStreamHandlerWrapper
 	 * This method is implemented by sub-classes and is used as the actual
 	 * entry point for lambdas.
 	 *
-	 * @param __exec Execution information.
+	 * @param __exec The instance for the current lambda execution. The
+	 * {@link com.amazonaws.services.lambda.runtime.Context} object can be
+	 * obtained by invoking the {@link IOpipeExecution#context()} method on
+	 * the {@code __exec} parameter.
 	 * @param __in The input stream.
 	 * @param __out The output stream.
 	 * @throws IOException On read/write errors.

--- a/src/main/java/com/iopipe/package-info.java
+++ b/src/main/java/com/iopipe/package-info.java
@@ -2,6 +2,10 @@
  * This package contians the classes and interfaces which are used to interact
  * with the IOpipe service.
  *
+ * The {@link com.amazonaws.services.lambda.runtime.Context} object can be
+ * obtained by invoking the {@link IOpipeExecution#context()} method in the
+ * instance of an {@link IOpipeExecution}.
+ *
  * @since 2017/12/12
  */
 


### PR DESCRIPTION
This documents how to access the AWS `Context` object, this is a bit more explicit in the JavaDocs compared to before.