### PR TITLE
Fix NullPointerException in threading statistics code (Fixes #96)

### DIFF
--- a/src/main/java/com/iopipe/plugin/profiler/ThreadStatistics.java
+++ b/src/main/java/com/iopipe/plugin/profiler/ThreadStatistics.java
@@ -131,6 +131,10 @@ public final class ThreadStatistics
 			long id = tids[i];
 			ThreadInfo info = __bean.getThreadInfo(id);
 			
+			// No information on the thread, ignore
+			if (info == null)
+				continue;
+			
 			// These might not be supported
 			long cputime = -1;
 			try


### PR DESCRIPTION
Fixes #96.

This should fix that `NullPointerException` in the threading statistics code. I ran it 75 times in a row and I have not hit the error, so I believe it to be fixed.