### PR TITLE
Add static means to obtain IOpipeExecution (Fixes #76)

### DIFF
--- a/src/main/java/com/iopipe/IOpipeExecution.java
+++ b/src/main/java/com/iopipe/IOpipeExecution.java
@@ -831,12 +831,13 @@ public final class IOpipeExecution
 	/**
 	 * Returns the current execution for the given thread.
 	 *
-	 * @return The execution context which is associated with this thread.
+	 * @return The execution context which is associated with this thread or
+	 * {@code null} if there is no associated execution.
 	 * @since 2018/07/30
 	 */
 	public static final IOpipeExecution currentExecution()
 	{
-		throw new Error("TODO");
+		return IOpipeService.__execution();
 	}
 	
 	/**

--- a/src/main/java/com/iopipe/IOpipeExecution.java
+++ b/src/main/java/com/iopipe/IOpipeExecution.java
@@ -829,6 +829,17 @@ public final class IOpipeExecution
 	}
 	
 	/**
+	 * Returns the current execution for the given thread.
+	 *
+	 * @return The execution context which is associated with this thread.
+	 * @since 2018/07/30
+	 */
+	public static final IOpipeExecution currentExecution()
+	{
+		throw new Error("TODO");
+	}
+	
+	/**
 	 * Checks if the given string is within the name limit before it is
 	 * reported.
 	 *

--- a/src/main/java/com/iopipe/IOpipeService.java
+++ b/src/main/java/com/iopipe/IOpipeService.java
@@ -15,9 +15,12 @@ import com.iopipe.plugin.IOpipePluginPostExecutable;
 import com.iopipe.plugin.IOpipePluginPreExecutable;
 import java.io.Closeable;
 import java.io.PrintStream;
+import java.lang.ref.Reference;
+import java.lang.ref.WeakReference;
 import java.util.Collection;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.HashMap;
@@ -60,6 +63,14 @@ public final class IOpipeService
 	/** The process stat when the process started. */
 	static final SystemMeasurement.Times _STAT_START =
 		SystemMeasurement.measureTimes(SystemMeasurement.SELF_PROCESS);
+	
+	/** Stores the execution for the current thread. */
+	private static final ThreadLocal<Reference<IOpipeExecution>> _EXECUTIONS =
+		new InheritableThreadLocal<>();
+	
+	/** Reference to the last execution that has occurred, just in case. */
+	private static final AtomicReference<Reference<IOpipeExecution>> _LAST =
+		new AtomicReference<>();
 	
 	/** If an instance was created then this will be that one instance. */
 	private static volatile IOpipeService _INSTANCE;
@@ -241,6 +252,19 @@ public final class IOpipeService
 		IOpipeExecution exec = new IOpipeExecution(this, config, __context,
 			measurement, threadgroup, nowtime, __input);
 		
+		// Use a reference to allow the execution to be garbage collected if
+		// it is no longer referred to or is in the stack of any method.
+		// Otherwise execution references will just sit around in memory and
+		// might not get freed ever.
+		ThreadLocal<Reference<IOpipeExecution>> executions = _EXECUTIONS;
+		executions.set(new WeakReference<>(exec));
+		
+		// Just in case there was no way to get the current execution in the
+		// event that the thread local could not be obtained
+		AtomicReference<Reference<IOpipeExecution>> lastexec = _LAST;
+		Reference<IOpipeExecution> refexec = new WeakReference<>(exec);
+		lastexec.compareAndSet(null, refexec);
+		
 		// If disabled, just run the function
 		IOpipeConfiguration config = this.config;
 		if (!enabled)
@@ -248,7 +272,16 @@ public final class IOpipeService
 			// Disabled lambdas could still rely on measurements, despite them
 			// not doing anything useful at all
 			this._badresultcount.incrementAndGet();
-			return __func.apply(exec);
+			
+			try
+			{
+				return __func.apply(exec);
+			}
+			finally
+			{
+				// Clear the last execution because it is no longer occuring
+				lastexec.compareAndSet(refexec, null);
+			}
 		}
 		
 		_LOGGER.debug(() -> String.format("Invoking context %08x",
@@ -325,6 +358,10 @@ public final class IOpipeService
 		// Generate and send result to server
 		if (watchdog == null || !watchdog._generated.getAndSet(true))
 			this.__sendRequest(exec.__buildRequest());
+		
+		// Clear the last execution that is occuring, but only if ours was
+		// still associated with it
+		lastexec.compareAndSet(refexec, null);
 		
 		// Throw the called exception as if the wrapper did not have any
 		// trouble
@@ -466,6 +503,31 @@ public final class IOpipeService
 			this.thrown = __t;
 			this.value = null;
 		}
+	}
+	
+	/**
+	 * Returns the current execution of the current thread.
+	 *
+	 * @return The current execution or {@code null} if it could not obtained.
+	 * @since 2018/07/30
+	 */
+	static final IOpipeExecution __execution()
+	{
+		Reference<IOpipeExecution> ref = _EXECUTIONS.get();
+		IOpipeExecution rv;
+		
+		// If there is no thread local then use the last instance
+		if (ref == null || null == (rv = ref.get()))
+		{
+			ref = _LAST.get();
+			
+			// No last execution exists either
+			if (ref == null || null == (rv = ref.get()))
+				return null;
+		}
+		
+		// There was a thread local or last execution
+		return rv;
 	}
 	
 	/**

--- a/src/main/java/com/iopipe/IOpipeService.java
+++ b/src/main/java/com/iopipe/IOpipeService.java
@@ -64,7 +64,7 @@ public final class IOpipeService
 	static final SystemMeasurement.Times _STAT_START =
 		SystemMeasurement.measureTimes(SystemMeasurement.SELF_PROCESS);
 	
-	/** Stores the execution for the current thread. */
+	/** Stores the execution for the current thread, inherited by child threads. */
 	private static final ThreadLocal<Reference<IOpipeExecution>> _EXECUTIONS =
 		new InheritableThreadLocal<>();
 	
@@ -257,12 +257,12 @@ public final class IOpipeService
 		// Otherwise execution references will just sit around in memory and
 		// might not get freed ever.
 		ThreadLocal<Reference<IOpipeExecution>> executions = _EXECUTIONS;
-		executions.set(new WeakReference<>(exec));
+		Reference<IOpipeExecution> refexec = new WeakReference<>(exec);
+		executions.set(refexec);
 		
 		// Just in case there was no way to get the current execution in the
 		// event that the thread local could not be obtained
 		AtomicReference<Reference<IOpipeExecution>> lastexec = _LAST;
-		Reference<IOpipeExecution> refexec = new WeakReference<>(exec);
 		lastexec.compareAndSet(null, refexec);
 		
 		// If disabled, just run the function

--- a/src/main/java/com/iopipe/plugin/trace/TraceUtils.java
+++ b/src/main/java/com/iopipe/plugin/trace/TraceUtils.java
@@ -46,5 +46,35 @@ public final class TraceUtils
 		return new TraceMeasurement(__exec.<TraceExecution>optionalPlugin(
 			TraceExecution.class) != null, __exec.measurement(), __name);
 	}
+	
+	/**
+	 * Creates a new instance of a class which is used to measure how long
+	 * a block of code has executed for. The returned object is
+	 * {@link AutoCloseable} and it is highly recommended to use
+	 * try-with-resources when utilizing it. When the method
+	 * {@link AutoCloseable#close()} is called the measurement will be
+	 * recorded. The measurement is returned and added to the report if
+	 * the plugin is enabled.
+	 *
+	 * The execution is derived from the current execution.
+	 *
+	 * @param __name The name of the measurement.
+	 * @return The measurement which was added to the report,
+	 * {@code null} is returned if the plugin is not enabled
+	 * @throws NullPointerException On null arguments.
+	 * @since 2018/01/30
+	 */
+	public static TraceMeasurement measure(String __name)
+		throws NullPointerException
+	{
+		if (__name == null)
+			throw new NullPointerException();
+		
+		IOpipeExecution exec = IOpipeExecution.currentExecution();
+		if (exec == null)
+			return null;
+		
+		return TraceUtils.measure(exec, __name);
+	}
 }
 

--- a/src/test/java/com/iopipe/Engine.java
+++ b/src/test/java/com/iopipe/Engine.java
@@ -41,8 +41,10 @@ public abstract class Engine
 		{
 			__DoEmptyMethod__::new,
 			__DoThrowException__::new,
-			(__e) -> new __DoTracePlugin__(__e, true),
-			(__e) -> new __DoTracePlugin__(__e, false),
+			(__e) -> new __DoTracePlugin__(__e, true, false),
+			(__e) -> new __DoTracePlugin__(__e, false, false),
+			(__e) -> new __DoTracePlugin__(__e, true, true),
+			(__e) -> new __DoTracePlugin__(__e, false, true),
 			__DoTimeOut__::new,
 			__DoInvalidToken__::new,
 			__DoCustomMetric__::new,

--- a/src/test/java/com/iopipe/__DoTracePlugin__.java
+++ b/src/test/java/com/iopipe/__DoTracePlugin__.java
@@ -38,6 +38,9 @@ class __DoTracePlugin__
 	
 	/** Is the plugin enabled? */
 	protected final boolean enabled;
+	
+	/** Is the execution passed as a parameter or derived from the current. */
+	protected final boolean derived;
 		
 	/** Sent with no exception? */
 	protected final BooleanValue noerror =
@@ -68,13 +71,17 @@ class __DoTracePlugin__
 	 *
 	 * @param __e The owning engine.
 	 * @param __enabled Is the plugin enabled?
+	 * @param __derived Is the IOpipeExecution passed via parameter or is
+	 * it derived from the current thread.
 	 * @since 2018/01/24
 	 */
-	__DoTracePlugin__(Engine __e, boolean __enabled)
+	__DoTracePlugin__(Engine __e, boolean __enabled, boolean __derived)
 	{
-		super(__e, "traceplugin-" + (__enabled ? "enabled" : "disabled"));
+		super(__e, "traceplugin-" + (__enabled ? "enabled" : "disabled") +
+			"-" + (__derived ? "parameter" : "derived"));
 		
 		this.enabled = __enabled;
+		this.derived = __derived;
 	}
 	
 	/**
@@ -189,7 +196,9 @@ class __DoTracePlugin__
 			});
 		
 		// Make a measurement via TraceUtils
-		try (TraceMeasurement c = TraceUtils.measure(__e, "byutils"))
+		try (TraceMeasurement c = (this.derived ?
+			TraceUtils.measure("byutils") :
+			TraceUtils.measure(__e, "byutils")))
 		{
 			// Small delay to skew time
 			try


### PR DESCRIPTION
This is a work in progress which adds a mean to obtain `IOpipeExecution` statically without needing to have it passed.