### PR TITLE
Do not spawn a new thread when invoking an execution (Fixes #84)

### DIFF
--- a/src/main/java/com/iopipe/IOpipeExecution.java
+++ b/src/main/java/com/iopipe/IOpipeExecution.java
@@ -57,9 +57,6 @@ public final class IOpipeExecution
 	/** The measurement. */
 	protected final IOpipeMeasurement measurement;
 	
-	/** The thread group this execution runs under. */
-	protected final ThreadGroup threadgroup;
-	
 	/** The starting time in milliseconds. */
 	protected final long starttimemillis;
 	
@@ -90,19 +87,18 @@ public final class IOpipeExecution
 	 * @since 2018/01/19
 	 */
 	IOpipeExecution(IOpipeService __sv, IOpipeConfiguration __conf,
-		Context __context, IOpipeMeasurement __m, ThreadGroup __tg, long __st,
+		Context __context, IOpipeMeasurement __m, long __st,
 		Object __input)
 		throws NullPointerException
 	{
 		if (__sv == null || __conf == null || __context == null ||
-			__m == null || __tg == null)
+			__m == null)
 			throw new NullPointerException();
 		
 		this.service = __sv;
 		this.config = __conf;
 		this.context = __context;
 		this.measurement = __m;
-		this.threadgroup = __tg;
 		this.starttimemillis = __st;
 		this.input = __input;
 	}
@@ -436,12 +432,12 @@ public final class IOpipeExecution
 	/**
 	 * Returns the thread group which this execution is running under.
 	 *
-	 * @return The thread group of this execution.
+	 * @return The thread group of this execution, may return .
 	 * @since 2018/02/09
 	 */
 	public final ThreadGroup threadGroup()
 	{
-		return this.threadgroup;
+		return Thread.currentThread().getThreadGroup();
 	}
 
 	/**

--- a/src/main/java/com/iopipe/IOpipeService.java
+++ b/src/main/java/com/iopipe/IOpipeService.java
@@ -456,5 +456,30 @@ public final class IOpipeService
 			return "Could not decode!";
 		}
 	}
+	
+	/**
+	 * Returns the current execution of the current thread.
+	 *
+	 * @return The current execution or {@code null} if it could not obtained.
+	 * @since 2018/07/30
+	 */
+	static final IOpipeExecution __execution()
+	{
+		Reference<IOpipeExecution> ref = _EXECUTIONS.get();
+		IOpipeExecution rv;
+		
+		// If there is no thread local then use the last instance
+		if (ref == null || null == (rv = ref.get()))
+		{
+			ref = _LAST.get();
+			
+			// No last execution exists either
+			if (ref == null || null == (rv = ref.get()))
+				return null;
+		}
+		
+		// There was a thread local or last execution
+		return rv;
+	}
 }
 

--- a/src/main/java/com/iopipe/__Shared__.java
+++ b/src/main/java/com/iopipe/__Shared__.java
@@ -1,0 +1,45 @@
+package com.iopipe;
+
+/**
+ * Internal shared variables and such
+ *
+ * @since 2018/08/01
+ */
+final class __Shared__
+{
+	/** The thread group to use main service threads under. */
+	static final ThreadGroup _SERVICE_THREAD_GROUP;
+	
+	/**
+	 * Initializes some shared variables.
+	 *
+	 * @since 2018/08/01
+	 */
+	static
+	{
+		// Setup a thread group where IOpipe's service threads are placed
+		// under
+		ThreadGroup stg = null;
+		try
+		{
+			stg = new ThreadGroup("IOpipe-ServiceThreads");
+		}
+		catch (SecurityException e)
+		{
+			// Just use our thread group
+			stg = Thread.currentThread().getThreadGroup();
+		}
+		
+		_SERVICE_THREAD_GROUP = stg;
+	}
+	
+	/**
+	 * Not used.
+	 *
+	 * @since 2018/08/01
+	 */
+	private __Shared__()
+	{
+	}
+}
+

--- a/src/main/java/com/iopipe/__TimeOutWatchDog__.java
+++ b/src/main/java/com/iopipe/__TimeOutWatchDog__.java
@@ -83,8 +83,8 @@ final class __TimeOutWatchDog__
 		this.coldstart = __cs;
 		this.execution = __exec;
 		
-		Thread timeoutthread = new Thread(this,
-			"IOpipe-WatchDog-" + System.identityHashCode(__context));
+		Thread timeoutthread = new Thread(__Shared__._SERVICE_THREAD_GROUP,
+			this, "IOpipe-WatchDog-" + System.identityHashCode(__context));
 		timeoutthread.setDaemon(true);
 		this.timeoutthread = timeoutthread;
 		timeoutthread.start();


### PR DESCRIPTION
This change was simple as it does not spawn a new thread.

All `Thread`s have to have a `ThreadGroup` so the profiler requires no changes, although it will only profile the name.

The profiler still works, but I am thinking of putting the IOpipe service threads in their own thread group so the profiler does not pick them up for profiling.