### PR TITLE
Fix fatal crash for IOPIPE_ENABLED environment variable. (Fixes #131)

### DIFF
--- a/src/main/java/com/iopipe/IOpipeConfiguration.java
+++ b/src/main/java/com/iopipe/IOpipeConfiguration.java
@@ -152,9 +152,9 @@ public final class IOpipeConfiguration
 		}
 		catch (IllegalArgumentException|SecurityException e)
 		{
-			Logger.error("Failed to initialize default configuration, " +
+			Logger.error(e, "Failed to initialize default configuration, " +
 				"your method will still run however it will not report " +
-				"anything to IOpipe.", e);
+				"anything to IOpipe.");
 		}
 		DEFAULT_CONFIG = use;
 		

--- a/src/main/java/com/iopipe/IOpipeConfiguration.java
+++ b/src/main/java/com/iopipe/IOpipeConfiguration.java
@@ -475,7 +475,9 @@ public final class IOpipeConfiguration
 					v = Objects.toString(e.getValue(), "");
 				
 				if (k.startsWith(_ENVIRONMENT_PLUGIN_PREFIX) &&
-					k.endsWith(_ENVIRONMENT_PLUGIN_SUFFIX))
+					k.endsWith(_ENVIRONMENT_PLUGIN_SUFFIX) &&
+					k.length() > (_ENVIRONMENT_PLUGIN_PREFIX.length() +
+						_ENVIRONMENT_PLUGIN_SUFFIX.length()))
 					rv.setPluginEnabled(k.substring(
 						_ENVIRONMENT_PLUGIN_PREFIX.length(),
 						k.length() - _ENVIRONMENT_PLUGIN_SUFFIX.length()),


### PR DESCRIPTION
This fixes a fatal crash for when `IOPIPE_ENABLED` is specified in the environment.

Also as a future security against this problem, I have opted to disable IOpipe if the default configuration cannot be built for some reason. So for example it will say this instead of crashing and doing nothing:

```
ERROR: Failure building default configuration, disabling IOpipe.: java.lang.StringIndexOutOfBoundsException: String index out of range: -1
```