### PR TITLE
Correct Master for 1.7.0 development.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ In the `pom.xml`, add the following block to your `<dependencies>`:
 <dependency>
   <groupId>com.iopipe</groupId>
   <artifactId>iopipe</artifactId>
-  <version>1.5.0</version>
+  <version>1.6.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,14 +3,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.iopipe</groupId>
   <artifactId>iopipe</artifactId>
-  <version>1.6.0-SNAPSHOT</version>
+  <version>1.6.0</version>
   <packaging>jar</packaging>
   <name>${project.groupId}:${project.artifactId}</name>
   <url>https://www.iopipe.com/</url>
   <scm>
     <connection>scm:git:https://github.com/iopipe/iopipe-java.git</connection>
     <url>https://github.com/iopipe/iopipe-java</url>
-    <tag>HEAD</tag>
+    <tag>v1.6.0</tag>
   </scm>
   <developers>
    <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <scm>
     <connection>scm:git:https://github.com/iopipe/iopipe-java.git</connection>
     <url>https://github.com/iopipe/iopipe-java</url>
-    <tag>v1.6.0</tag>
+    <tag>v1.7.0-SNAPSHOT</tag>
   </scm>
   <developers>
    <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -3,14 +3,14 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.iopipe</groupId>
   <artifactId>iopipe</artifactId>
-  <version>1.6.0</version>
+  <version>v1.7.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>${project.groupId}:${project.artifactId}</name>
   <url>https://www.iopipe.com/</url>
   <scm>
     <connection>scm:git:https://github.com/iopipe/iopipe-java.git</connection>
     <url>https://github.com/iopipe/iopipe-java</url>
-    <tag>v1.7.0-SNAPSHOT</tag>
+    <tag>HEAD</tag>
   </scm>
   <developers>
    <developer>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.iopipe</groupId>
   <artifactId>iopipe</artifactId>
-  <version>v1.7.0-SNAPSHOT</version>
+  <version>1.7.0-SNAPSHOT</version>
   <packaging>jar</packaging>
   <name>${project.groupId}:${project.artifactId}</name>
   <url>https://www.iopipe.com/</url>

--- a/src/main/java/com/iopipe/IOpipeConstants.java
+++ b/src/main/java/com/iopipe/IOpipeConstants.java
@@ -15,7 +15,7 @@ public interface IOpipeConstants
 {
 	/** The version for this agent. */
 	public static final String AGENT_VERSION =
-		"1.5.0";
+		"1.6.0";
 	
 	/** This is used to determine the load time of the service. */
 	public static final long LOAD_TIME =


### PR DESCRIPTION
Due to an issue with the current release process the release tag is on its own tag outside of master and has to be merged back in.