### PR TITLE
Organize the README (Fixes #124)

### DIFF
--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -2,6 +2,10 @@
 
 This document contains information on how to write and use plugins for IOpipe.
 
+ * [Using Plugins](#using-plugins)
+   * [Detailed Instructions](#detailed-instructions)
+ * [Writing Plugins](#writing-plugins)
+
 For every invocation that is performed there is a unique object which
 represents the state of the plugin for each plugin as they are needed. This
 execution state is initialized when the plugin is first referenced. When the

--- a/PROFILER.md
+++ b/PROFILER.md
@@ -5,17 +5,30 @@ The IOpipe profiler generates snapshots which can be opened and parsed with
 for Windows and Mac, and may also be installed on Debian and Ubuntu based
 systems by running `apt-get install visualvm`.
 
+ * [Enabling Profiling](#enabling-profiling)
+   * [For Serverless Framework](#for-serverless-framework)
+ * [Customizing Profiling](#customizing-profiling)
+ * [Getting Profiling Data](#getting-profiling-data)
+ * [How To Use Sampling-Only Profiler Data](#how-to-use-sampling-only-profiler-data)
+ * [Statistics Data](#statistics-data)
+   * [Timing](#timing)
+   * [Class Loading](#class-loading)
+   * [Garbage Collection](#garbage-collection)
+   * [Memory](#memory)
+   * [Threads](#threads)
+   * [Buffer Pools](#buffer-pools)
+
 There is currently one mode of operation, which is a sampling-only profiler
 which inspects the state of all threads to determine how long they have been
 running for. This mode does not require any code to be modified to support profiling
 so all code run by your Lambda functions will be profiled automatically, as
 long as the profiler is enabled.
 
-## Enabling Profiling
+# Enabling Profiling
 
 Set the environment variable IOPIPE_PROFILER_ENABLED to `true`
 
-### For Serverless Framework:
+## For Serverless Framework
 
 In the `serverless.yml` file, under `functions:`, `(your_function_name_here):`, `environment:`, set the environment variable `IOPIPE_PROFILER_ENABLED` to `true`
 
@@ -52,7 +65,7 @@ debugging the profiler.
      instead.
    * The prefix should consist of characters which make up valid filenames.
 
-## Getting Profiling Data
+# Getting Profiling Data
 
 When the profiler is enabled, .zip files containing the profiling data may be downloaded from the individual
 invocation information page, under 'Profiling'. Unzip it, then load the file in VisualVM as a profile snapshot.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ applications running on AWS Lambda using [IOpipe](https://www.iopipe.com).
  * [Building With IOpipe](#building-with-iopipe)
    * [Maven](#maven)
    * [Gradle](#gradle)
- * [Wrapping Your Lambda](#wrapping-your-lambda)'
+ * [Wrapping Your Lambda](#wrapping-your-lambda)
    * [Implement `com.iopipe.SimpleRequestHandlerWrapper`](#implement-comiopipesimplerequesthandlerwrapper)
    * [Implement `com.iopipe.SimpleRequestStreamHandlerWrapper`](#implement-comiopipesimplerequeststreamhandlerwrapper)
    * [Wrapping Without A Helper Class](#wrapping-without-a-helper-class)

--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ protected final String wrappedHandleRequest(IOpipeExecution __exec, String __n)
 
 For this agent:
 
- * [Project Code of Conduct](CODE_OF_CONDUCT.md)
+ * [Code of Conduct](CODE_OF_CONDUCT.md)
  * [JavaDocs](https://www.javadoc.io/doc/com.iopipe/iopipe)
 
 In general:

--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ applications running on AWS Lambda using [IOpipe](https://www.iopipe.com).
 It is licensed under the Apache 2.0.
 
  * [IOpipe](https://iopipe.com/)
- * [JavaDocs](https://www.javadoc.io/doc/com.iopipe/iopipe)
- * [Code of Conduct](CODE_OF_CONDUCT.md)
  * [Building With IOpipe](#building-with-iopipe)
    * [Maven](#maven)
    * [Gradle](#gradle)
@@ -200,6 +198,13 @@ protected final String wrappedHandleRequest(IOpipeExecution __exec, String __n)
 ```
 
 # Resources
+
+For this agent:
+
+ * [Project Code of Conduct](CODE_OF_CONDUCT.md)
+ * [JavaDocs](https://www.javadoc.io/doc/com.iopipe/iopipe)
+
+In general:
 
  * [Java Programming Model on AWS](https://docs.aws.amazon.com/lambda/latest/dg/java-programming-model.html)
  * [Logging on AWS](https://docs.aws.amazon.com/lambda/latest/dg/java-logging.html)

--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ For this agent:
 
  * [Code of Conduct](CODE_OF_CONDUCT.md)
  * [JavaDocs](https://www.javadoc.io/doc/com.iopipe/iopipe)
+ * [Writing and Using IOpipe Plugins for Java](PLUGINS.md)
 
 In general:
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It is licensed under the Apache 2.0.
    * [Implement `com.iopipe.SimpleRequestStreamHandlerWrapper`](#implement-comiopipesimplerequeststreamhandlerwrapper)
    * [Wrapping Without A Helper Class](#wrapping-without-a-helper-class)
  * [Accessing the AWS `Context` Object](#accessing-the-aws-context-object)
- * [Monitoring](#monitoring)
+ * [Measuring and Monitoring](#measuring-and-monitoring)
    * [Custom Metrics](#custom-metrics)
    * [Event Info](#event-info)
    * [Labels](#labels)
@@ -202,7 +202,7 @@ protected final String wrappedHandleRequest(IOpipeExecution __exec, String __n)
 }
 ```
 
-# Monitoring
+# Measuring and Monitoring
 
 ## Custom Metrics
 

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ service.<String>run(context, (exec) -> "Hello World!", input);
 # Configuration
 
 IOpipe may be configured using system properties and/or environment variables.
-Note that on AWS Lambda configuration must be done using environ,ent variables.
+Note that on AWS Lambda, environment variables must be used.
 If you do specify system properties then they will take precedence before
 environment variables.
 

--- a/README.md
+++ b/README.md
@@ -6,11 +6,15 @@ IOpipe Telemetry Agent for Java
 This project provides analytics and distributed tracing for event-driven
 applications running on AWS Lambda using [IOpipe](https://www.iopipe.com).
 
+It is licensed under the Apache 2.0.
+
  * [IOpipe](https://iopipe.com/)
  * [JavaDocs](https://www.javadoc.io/doc/com.iopipe/iopipe)
+ * [Code of Conduct](CODE_OF_CONDUCT.md)
  * [Building With IOpipe](#building-with-iopipe)
    * [Maven](#maven)
    * [Gradle](#gradle)
+ * [Configuration](#configuration)
  * [Wrapping Your Lambda](#wrapping-your-lambda)
    * [Implement `com.iopipe.SimpleRequestHandlerWrapper`](#implement-comiopipesimplerequesthandlerwrapper)
    * [Implement `com.iopipe.SimpleRequestStreamHandlerWrapper`](#implement-comiopipesimplerequeststreamhandlerwrapper)
@@ -41,6 +45,11 @@ single JAR.
 
 If you are using third-party IOpipe plugins or are writing your own you should
 in your POM include the [service resource transformer for shading](https://maven.apache.org/plugins/maven-shade-plugin/examples/resource-transformers.html#ServicesResourceTransformer).
+
+If your JAR file is too big you may try [reducing the size of your JAR using the shade plugin](https://maven.apache.org/plugins/maven-shade-plugin/examples/includes-excludes.html).
+If that does not reduce the size of your JAR enough and you need more space
+you can __strip all debugging and source line information__, __which makes
+debugging much more difficult__, by running `pack200 -r -G path-to-target.jar`.
 
 ## Gradle
 
@@ -135,209 +144,12 @@ service.<String>run(context, (exec) -> "Hello World!");
 service.<String>run(context, (exec) -> "Hello World!", input);
 ```
 
-# Accessing the AWS `Context` Object
+# Configuration
 
-The AWS `Context` object may be obtained by invoking `context()` on
-the `IOpipeExecution` instance. For example:
-
-```java
-protected final String wrappedHandleRequest(IOpipeExecution __exec, String __n)
-{
-    // Code here...
-    
-    Context context = __exec.context();
-    
-    // Code here...
-}
-```
-
-# Resources
-
- * [Java Programming Model on AWS](https://docs.aws.amazon.com/lambda/latest/dg/java-programming-model.html)
- * [Logging on AWS](https://docs.aws.amazon.com/lambda/latest/dg/java-logging.html)
-
---------------------------------------------
-# OLD STUFF BELOW
---------------------------------------------
-
-# Installation & usage
-
-This documentation mostly refers to using Maven for your project, if you
-are using Gradle, 
-
-Using the IOpipe service with your pre-existing and newly created classes is
-quite simple. If you are using Maven it requires modification of your `pom.xml`
-file, otherwise you may include the JAR file of the library to your project.
-
-More information on using Java Lambdas on Amazon AWS can be obtained at:
-<https://docs.aws.amazon.com/lambda/latest/dg/java-programming-model.html>.
-
-Logging can be enabled by following the instructions at:
-<https://docs.aws.amazon.com/lambda/latest/dg/java-logging.html>.
-
-In the `pom.xml`, add the following block to your `<dependencies>`:
-
-
-
-For debugging on Amazon AWS, the additional dependency is required:
-
-```xml
-<dependency>
-  <groupId>com.amazonaws</groupId>
-  <artifactId>aws-lambda-java-log4j2</artifactId>
-  <version>1.0.0</version>
-</dependency>
-```
-
-If you are using log4j2 in your project then the following transformer must
-be specified:
-
-```xml
-<configuration>
-  <transformers>
-    <transformer implementation="com.github.edwgiz.mavenShadePlugin.log4j2CacheTransformer.PluginsCacheFileTransformer" />
-  </transformers>
-</configuration>
-```
-
-It is highly recommended to configure the shade plugin so that it merges service resources together, this will be _especially_ important if you plan to
-use a number of plugins which may exist across different packages. By default
-the shade plugin will not merge resources for you and as a result plugins will
-appear to disappear. As such, add the following transformer to the shade
-plugin:
-
-```xml
-<configuration>
-  <transformers>
-    <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
-  </transformers>
-</configuration>
-```
-
-To create a package which is ready for deployment you may run:
-
-```bash
-mvn package
-```
-
-If you wish to strip all debugging information in the JAR file __including__
-__potentially meaningful source lines to stack traces__ you can run the
-following command:
-
-```bash
-pack200 -r -G file.jar
-```
-
-Deployment is the same as other Java programs on the Amazon Lambda platform.
-
-## Configuration
-
-There are three ways to use the service:
-
- * If you are currently implementing `RequestHandler`,
-   implement `com.iopipe.SimpleRequestHandlerWrapper`
- * If you are currently implementing `RequestStreamHandler`,
-   implement `com.iopipe.SimpleRequestStreamHandlerWrapper`
- * You may also interact with IOpipe directly
-
-### Implement `com.iopipe.SimpleRequestHandlerWrapper`.
-
-This class provides an implementation of `RequestHandler<I, O>`.
-
-Add the following import statement:
-
-```java
-import com.iopipe.IOpipeExecution;
-import com.iopipe.SimpleRequestHandlerWrapper;
-```
-
-Add a class which extends:
-
-```java
-SimpleRequestHandlerWrapper<I, O>
-```
-
-Implement the following method:
-
-```java
-protected O wrappedHandleRequest(IOpipeExecution __exec, I __input)
-```
-
-### Implement `com.iopipe.SimpleRequestStreamHandlerWrapper`.
-
-This class provides an implementation of `RequestStreamHandler`.
-
-Add the following import statements:
-
-```java
-import com.amazonaws.services.lambda.runtime.Context;
-import com.iopipe.IOpipeExecution;
-import com.iopipe.SimpleRequestStreamHandlerWrapper;
-import java.io.InputStream;
-import java.io.IOException;
-import java.io.OutputStream;
-```
-
-Add a class which extends:
-
-```java
-SimpleRequestStreamHandlerWrapper
-```
-
-Implement the following method:
-
-```java
-protected void wrappedHandleRequest(IOpipeExecution __exec, InputStream __in, OutputStream __out) throws IOException
-```
-
-### Using the service directly.
-
-This may be used with any request handler such as `RequestHandler` or
-`RequestStreamHandler`, although it is not limited to those interfaces.
-
-Add the following import statements:
-
-```java
-import com.amazonaws.services.lambda.runtime.Context;
-import com.iopipe.IOpipeService;
-```
-
-Obtain an instance of `IOpipeService`:
-
-```java
-IOpipeService service = IOpipeService.instance();
-```
-
-Run by passing a lambda or a class which implements the functional interface
-`Function<IOpipeExecution, R>`, an input object may be specified which is
-usable by plugins that require it:
-
-```java
-service.<String>run(context, (exec) -> "Hello World!");
-service.<String>run(context, (exec) -> "Hello World!", input);
-```
-
-### Accessing the AWS `Context` Object
-
-The AWS `Context` object may be obtained by invoking `context()` on
-the `IOpipeExecution` instance. For example:
-
-```java
-protected final String wrappedHandleRequest(IOpipeExecution __exec, String __n)
-{
-    // Code here...
-    
-    Context context = __exec.context();
-    
-    // Code here...
-}
-```
-
-### Setting system properties and environment variables
-
-Set up IOpipe using system properties or environment variables. N.B., it is necessary
-to use environment variables for running on AWS Lambda. System properties will
-take precedence when available.
+IOpipe may be configured using system properties and/or environment variables.
+Note that on AWS Lambda configuration must be done using environ,ent variables.
+If you do specify system properties then they will take precedence before
+environment variables.
 
 * `com.iopipe.enabled` or `IOPIPE_ENABLED`
   * If this is set and if the value is `true` (ignoring case) then the library
@@ -371,6 +183,31 @@ at:
 
 The associated package is `com.iopipe`.
 
+# Accessing the AWS `Context` Object
+
+The AWS `Context` object may be obtained by invoking `context()` on
+the `IOpipeExecution` instance. For example:
+
+```java
+protected final String wrappedHandleRequest(IOpipeExecution __exec, String __n)
+{
+    // Code here...
+    
+    Context context = __exec.context();
+    
+    // Code here...
+}
+```
+
+# Resources
+
+ * [Java Programming Model on AWS](https://docs.aws.amazon.com/lambda/latest/dg/java-programming-model.html)
+ * [Logging on AWS](https://docs.aws.amazon.com/lambda/latest/dg/java-logging.html)
+
+--------------------------------------------
+# OLD STUFF BELOW
+--------------------------------------------
+
 ## Custom Metrics
 
 To use custom metrics, you can simply call the following two methods in the
@@ -398,6 +235,7 @@ It operates on the given input classes:
  * `com.amazonaws.services.lambda.runtime.events.S3Event`
  * `com.amazonaws.services.lambda.runtime.events.ScheduledEvent`
  * `com.amazonaws.services.lambda.runtime.events.SNSEvent`
+ * `com.amazonaws.services.lambda.runtime.events.SQSEvent`
  * `com.amazonaws.services.s3.event.S3EventNotification`
 
 By default this plugin is enabled and requires no changes to your code unless
@@ -466,55 +304,4 @@ Disabling the plugin can be done as followed:
 
  * Setting the system property `com.iopipe.plugin.trace` to `false`.
  * Setting the environment variable `IOPIPE_TRACE_ENABLED` to `false`.
-
-# Building and Installing the Project Locally
-
-This project requires at least Java 8 to run and additionally required Maven
-to build.
-
-Compile the project:
-
-```bash
-mvn compile
-```
-
-Compile JAR package:
-
-```bash
-mvn package
-```
-
-Run tests:
-
-```bash
-mvn test
-```
-
-Clean build:
-
-```bash
-mvn clean
-```
-
-Install the project into your own Maven repository:
-
-```bash
-mvn install
-```
-
-Generate Maven informational pages:
-
-```bash
-mvn site
-```
-
-generate JavaDoc:
-
-```bash
-mvn javadoc:javadoc
-```
-
-## License
-
-Apache 2.0
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ applications running on AWS Lambda using [IOpipe](https://www.iopipe.com).
 
 It is licensed under the Apache 2.0.
 
- * [IOpipe](https://iopipe.com/)
  * [Building With IOpipe](#building-with-iopipe)
    * [Maven](#maven)
    * [Gradle](#gradle)

--- a/README.md
+++ b/README.md
@@ -6,12 +6,55 @@ IOpipe Telemetry Agent for Java
 This project provides analytics and distributed tracing for event-driven
 applications running on AWS Lambda using [IOpipe](https://www.iopipe.com).
 
-The JavaDocs for this library are available on [JavaDoc.io](https://www.javadoc.io/doc/com.iopipe/iopipe).
+ * [IOpipe](https://iopipe.com/)
+ * [JavaDocs](https://www.javadoc.io/doc/com.iopipe/iopipe)
+ * [Building With IOpipe](#building-with-iopipe)
+   * [Maven](#maven)
+   * [Gradle](#gradle)
+ * [Resources](#resources)
+
+# Building With IOpipe
+
+This agent is available in Maven Central and Bintray and either can be used for
+including the agent in your library.
+
+## Maven
+
+Your `pom.xml` file may be modified to include the following dependency:
+
+```xml
+<dependency>
+  <groupId>com.iopipe</groupId>
+  <artifactId>iopipe</artifactId>
+  <version>1.6.0</version>
+</dependency>
+```
+
+It is highly recommended that you use the [Shade Plugin](https://maven.apache.org/plugins/maven-shade-plugin/index.html)
+for Maven since AWS requires that all classes and files are packed into a
+single JAR.
+
+If you are using third-party IOpipe plugins or are writing your own you should
+in your POM include the [service resource transformer for shading](https://maven.apache.org/plugins/maven-shade-plugin/examples/resource-transformers.html#ServicesResourceTransformer).
+
+## Gradle
+
+For a basic configuration with Gradle there is [an example build.gradle](https://github.com/iopipe/examples/blob/master/java/build.gradle) that you may use as a base for your
+project.
+
+# Resources
+
+ * [Java Programming Model on AWS](https://docs.aws.amazon.com/lambda/latest/dg/java-programming-model.html)
+ * [Logging on AWS](https://docs.aws.amazon.com/lambda/latest/dg/java-logging.html)
+
+--------------------------------------------
+# OLD STUFF BELOW
+--------------------------------------------
 
 # Installation & usage
 
 This documentation mostly refers to using Maven for your project, if you
-are using Gradle, [there is a basic build.gradle available in the examples project](https://github.com/iopipe/examples/blob/master/java/build.gradle).
+are using Gradle, 
 
 Using the IOpipe service with your pre-existing and newly created classes is
 quite simple. If you are using Maven it requires modification of your `pom.xml`
@@ -25,13 +68,7 @@ Logging can be enabled by following the instructions at:
 
 In the `pom.xml`, add the following block to your `<dependencies>`:
 
-```xml
-<dependency>
-  <groupId>com.iopipe</groupId>
-  <artifactId>iopipe</artifactId>
-  <version>1.6.0</version>
-</dependency>
-```
+
 
 For debugging on Amazon AWS, the additional dependency is required:
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ It is licensed under the Apache 2.0.
    * [Implement `com.iopipe.SimpleRequestStreamHandlerWrapper`](#implement-comiopipesimplerequeststreamhandlerwrapper)
    * [Wrapping Without A Helper Class](#wrapping-without-a-helper-class)
  * [Accessing the AWS `Context` Object](#accessing-the-aws-context-object)
+ * [Monitoring](#monitoring)
+   * [Custom Metrics](#custom-metrics)
+   * [Event Info](#event-info)
+   * [Labels](#labels)
+   * [Profiling](#profiling)
+   * [Tracing](#tracing)
  * [Resources](#resources)
 
 # Building With IOpipe
@@ -196,21 +202,7 @@ protected final String wrappedHandleRequest(IOpipeExecution __exec, String __n)
 }
 ```
 
-# Resources
-
-For this agent:
-
- * [Code of Conduct](CODE_OF_CONDUCT.md)
- * [JavaDocs](https://www.javadoc.io/doc/com.iopipe/iopipe)
-
-In general:
-
- * [Java Programming Model on AWS](https://docs.aws.amazon.com/lambda/latest/dg/java-programming-model.html)
- * [Logging on AWS](https://docs.aws.amazon.com/lambda/latest/dg/java-logging.html)
-
---------------------------------------------
-# OLD STUFF BELOW
---------------------------------------------
+# Monitoring
 
 ## Custom Metrics
 
@@ -308,4 +300,16 @@ Disabling the plugin can be done as followed:
 
  * Setting the system property `com.iopipe.plugin.trace` to `false`.
  * Setting the environment variable `IOPIPE_TRACE_ENABLED` to `false`.
+
+# Resources
+
+For this agent:
+
+ * [Code of Conduct](CODE_OF_CONDUCT.md)
+ * [JavaDocs](https://www.javadoc.io/doc/com.iopipe/iopipe)
+
+In general:
+
+ * [Java Programming Model on AWS](https://docs.aws.amazon.com/lambda/latest/dg/java-programming-model.html)
+ * [Logging on AWS](https://docs.aws.amazon.com/lambda/latest/dg/java-logging.html)
 


### PR DESCRIPTION
This organizes the README (and the other main documentation files).

Statistics for the README:
 * Lines: 374 -> 316
 * Words: 1491 -> 1450
 * Characters (with spaces): 10794 -> 10563
 * Characters (no spaces): 9278 -> 9139
 * Bytes: 10794 -> 10563