### PR TITLE
Record start time properly for measurements and record more overhead. (Fixes #147 and #135)

### DIFF
--- a/src/main/java/com/iopipe/IOpipeMeasurement.java
+++ b/src/main/java/com/iopipe/IOpipeMeasurement.java
@@ -36,10 +36,6 @@ public final class IOpipeMeasurement
 	private final AtomicReference<Throwable> _thrown =
 		new AtomicReference<>();
 
-	/** The duration of execution in nanoseconds. */
-	private final AtomicLong _duration =
-		new AtomicLong(Long.MIN_VALUE);
-
 	/**
 	 * Initializes the measurement holder.
 	 *
@@ -214,11 +210,15 @@ public final class IOpipeMeasurement
 	 *
 	 * @return The execution duration, if this is negative then it is not
 	 * valid.
+	 * @deprecated This value is only set when the invocation has finished and
+	 * the report is to be generated, so it always will return
+	 * {@link Long#MIN_VALUE}.
 	 * @since 2017/12/15
 	 */
+	@Deprecated
 	public long getDuration()
 	{
-		return this._duration.get();
+		return Long.MIN_VALUE;
 	}
 	
 	/**
@@ -275,19 +275,7 @@ public final class IOpipeMeasurement
 	{
 		return this.coldstart;
 	}
-
-	/**
-	 * Sets the duration of execution.
-	 *
-	 * @param __ns The execution duration in nanoseconds, this may only be set
-	 * once.
-	 * @since 2017/12/15
-	 */
-	void __setDuration(long __ns)
-	{
-		this._duration.compareAndSet(Long.MIN_VALUE, __ns);
-	}
-
+	
 	/**
 	 * Sets the throwable generated during execution.
 	 *

--- a/src/main/java/com/iopipe/PerformanceEntry.java
+++ b/src/main/java/com/iopipe/PerformanceEntry.java
@@ -70,11 +70,11 @@ public final class PerformanceEntry
 		if (rv != 0)
 			return rv;
 		
-		rv = Long.compare(this.durationns, __o.durationns);
+		rv = this.name.compareTo(__o.name);
 		if (rv != 0)
 			return rv;
 		
-		rv = this.name.compareTo(__o.name);
+		rv = Long.compare(this.durationns, __o.durationns);
 		if (rv != 0)
 			return rv;
 		

--- a/src/main/java/com/iopipe/plugin/trace/TraceMeasurement.java
+++ b/src/main/java/com/iopipe/plugin/trace/TraceMeasurement.java
@@ -60,8 +60,7 @@ public final class TraceMeasurement
 		// Create initial start mark if this is enabled
 		if (__enabled)
 			__m.addPerformanceEntry(new PerformanceEntry("start:" + __name,
-				"mark", startns - IOpipeConstants.LOAD_TIME_NANOS,
-				System.currentTimeMillis(), 0));
+				"mark", startns, System.currentTimeMillis(), 0));
 	}
 	
 	/**
@@ -78,16 +77,15 @@ public final class TraceMeasurement
 				// There are two end marks, one for the end mark and the
 				// actual duration but they end at the same time
 				long endns = System.nanoTime(),
-					endms = System.currentTimeMillis(),
-					relendns = endns -  - IOpipeConstants.LOAD_TIME_NANOS;
+					endms = System.currentTimeMillis();
 				
 				IOpipeMeasurement measurement = this.measurement;
 				String name = this.name;
 				
 				measurement.addPerformanceEntry(new PerformanceEntry(
-					"end:" + name, "mark", relendns, endms, 0));
+					"end:" + name, "mark", endns, endms, 0));
 				measurement.addPerformanceEntry(new PerformanceEntry(
-					"measure:" + name, "measure", relendns, endms,
+					"measure:" + name, "measure", endns, endms,
 					endns - this.startns));
 			}
 	}

--- a/src/test/java/com/iopipe/IntegerValue.java
+++ b/src/test/java/com/iopipe/IntegerValue.java
@@ -37,6 +37,17 @@ public final class IntegerValue
 	}
 	
 	/**
+	 * Adds to the value atomically then returns it.
+	 *
+	 * @return The new value.
+	 * @since 2018/08/15
+	 */
+	public int addAndGet(int __v)
+	{
+		return this.value.addAndGet(__v);
+	}
+	
+	/**
 	 * Increments the value then returns it.
 	 *
 	 * @return The value after incrementing.

--- a/src/test/java/com/iopipe/__DoTracePlugin__.java
+++ b/src/test/java/com/iopipe/__DoTracePlugin__.java
@@ -29,9 +29,13 @@ class __DoTracePlugin__
 		new String[]
 		{
 			"start:byplugin", "mark",
-			"start:byutils", "mark",
+			
+			
 			"end:byplugin", "mark",
 			"measure:byplugin", "measure",
+			
+			"start:byutils", "mark",
+			
 			"end:byutils", "mark",
 			"measure:byutils", "measure",
 		};

--- a/src/test/java/com/iopipe/__DoTracePlugin__.java
+++ b/src/test/java/com/iopipe/__DoTracePlugin__.java
@@ -29,13 +29,9 @@ class __DoTracePlugin__
 		new String[]
 		{
 			"start:byplugin", "mark",
-			
-			
 			"end:byplugin", "mark",
 			"measure:byplugin", "measure",
-			
 			"start:byutils", "mark",
-			
 			"end:byutils", "mark",
 			"measure:byutils", "measure",
 		};

--- a/src/test/java/com/iopipe/__DoTracePlugin__.java
+++ b/src/test/java/com/iopipe/__DoTracePlugin__.java
@@ -99,7 +99,7 @@ class __DoTracePlugin__
 		boolean enabled = this.enabled;
 		
 		super.assertEquals(enabled, this.tracepluginexecuted);
-		super.assertEquals((enabled ? _ORDER.length / 2 : 0), this.orderdepth);
+		super.assertEquals((enabled ? (1 << (_ORDER.length / 2) : 0)) - 1, this.orderdepth);
 		super.assertEquals(enabled, this.hasautolabel);
 	}
 	
@@ -150,7 +150,7 @@ class __DoTracePlugin__
 			
 			if (Objects.equals(e.name(), wv) &&
 				Objects.equals(e.type(), wt))
-				orderdepth.incrementAndGet();
+				orderdepth.addAndGet(1 << i);
 		}
 		
 		if (event.labels.contains("@iopipe/plugin-trace"))

--- a/src/test/java/com/iopipe/__DoTracePlugin__.java
+++ b/src/test/java/com/iopipe/__DoTracePlugin__.java
@@ -99,7 +99,7 @@ class __DoTracePlugin__
 		boolean enabled = this.enabled;
 		
 		super.assertEquals(enabled, this.tracepluginexecuted);
-		super.assertEquals((enabled ? (1 << (_ORDER.length / 2) : 0)) - 1, this.orderdepth);
+		super.assertEquals((enabled ? ((1 << (_ORDER.length / 2)) - 1) : 0), this.orderdepth);
 		super.assertEquals(enabled, this.hasautolabel);
 	}
 	


### PR DESCRIPTION
This fixes measurements being incorrect and additionally records more overhead sooner and just before the report is sent to IOpipe.

Fixes #147 and #135.