### PR TITLE
Correct infinite/NaN disk usage being reported. (Fixes #154)

### DIFF
--- a/src/main/java/com/iopipe/SystemMeasurement.java
+++ b/src/main/java/com/iopipe/SystemMeasurement.java
@@ -496,8 +496,10 @@ public final class SystemMeasurement
 			this.usedmib = (double)__usedbytes / 1048576.0;
 			this.freemib = (__totalbytes - __usedbytes) / 1048576.0;
 			
-			this.usedpercent = Double.min(1.0, Double.max(0.0,
+			double usedpercent = Double.min(1.0, Double.max(0.0,
 				(double)__usedbytes / (double)__totalbytes));
+			this.usedpercent = ((Double.isInfinite(usedpercent) ||
+				Double.isNaN(usedpercent)) ? 100.0 : usedpercent);
 		}
 	}
 	

--- a/src/main/java/com/iopipe/SystemMeasurement.java
+++ b/src/main/java/com/iopipe/SystemMeasurement.java
@@ -499,7 +499,7 @@ public final class SystemMeasurement
 			double usedpercent = Double.min(1.0, Double.max(0.0,
 				(double)__usedbytes / (double)__totalbytes));
 			this.usedpercent = ((Double.isInfinite(usedpercent) ||
-				Double.isNaN(usedpercent)) ? 100.0 : usedpercent);
+				Double.isNaN(usedpercent)) ? 1.0 : usedpercent);
 		}
 	}
 	


### PR DESCRIPTION
This corrects and falls back if the disk usage percent ends up being infinite or NaN.