### PR TITLE
Generate sources and JavaDoc, for manual deploys. (Fixes #189)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,33 @@
   </properties>
   <build>
     <plugins>
+      <!-- Used to make it so the JavaDoc and sources are included. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-javadocs</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <!-- End of sources/javadoc inclusion. -->
+      
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>


### PR DESCRIPTION
If a manual deploy needs to be done for the Java agent, this will generate the needed javadoc and sources for it to be uploaded.