### PR TITLE
Use fallback `Context` if one was not specified. (Fixes #186)

### DIFF
--- a/src/main/java/com/iopipe/IOpipeService.java
+++ b/src/main/java/com/iopipe/IOpipeService.java
@@ -313,7 +313,7 @@ public final class IOpipeService
 		
 		// If no context is specified, generate one
 		if (__context == null)
-			__context = new __PseudoContext__();
+			__context = new __PseudoContext__(__input);
 		
 		// If an execution is already running, just ignore wrapping and
 		// generating events and just call it directly

--- a/src/main/java/com/iopipe/IOpipeService.java
+++ b/src/main/java/com/iopipe/IOpipeService.java
@@ -292,7 +292,8 @@ public final class IOpipeService
 	 * Runs the specified function and generates a report.
 	 *
 	 * @param <R> The value to return.
-	 * @param __context The context provided by the AWS service.
+	 * @param __context The context provided by the AWS service, if one is
+	 * not provided then one will be generated.
 	 * @param __func The lambda function to execute, measure, and generate a
 	 * report for.
 	 * @param __input An object which should specify the object which was
@@ -307,8 +308,12 @@ public final class IOpipeService
 		Function<IOpipeExecution, R> __func, Object __input)
 		throws Error, NullPointerException, RuntimeException
 	{
-		if (__context == null || __func == null)
+		if (__func == null)
 			throw new NullPointerException();
+		
+		// If no context is specified, generate one
+		if (__context == null)
+			__context = new __PseudoContext__();
 		
 		// If an execution is already running, just ignore wrapping and
 		// generating events and just call it directly
@@ -367,9 +372,6 @@ public final class IOpipeService
 				lastexec.compareAndSet(refexec, null);
 			}
 		}
-		
-		Logger.debug("Invoking context {}.",
-			() -> System.identityHashCode(__context));
 		
 		// Add auto-label for coldstart
 		if (coldstarted)

--- a/src/main/java/com/iopipe/IOpipeService.java
+++ b/src/main/java/com/iopipe/IOpipeService.java
@@ -398,9 +398,10 @@ public final class IOpipeService
 		// Timeouts can be disabled if the timeout window is zero, but they
 		// may also be unsupported if the time remaining in the context is zero
 		__TimeOutWatchDog__ watchdog = null;
-		int windowtime;
+		int windowtime,
+			remainingtime = __context.getRemainingTimeInMillis();
 		if ((windowtime = config.getTimeOutWindow()) > 0 &&
-			__context.getRemainingTimeInMillis() > 0)
+			remainingtime > 0 && remainingtime < Integer.MAX_VALUE)
 			watchdog = new __TimeOutWatchDog__(this, __context,
 				Thread.currentThread(), windowtime, coldstarted, exec);
 		

--- a/src/main/java/com/iopipe/__PseudoContext__.java
+++ b/src/main/java/com/iopipe/__PseudoContext__.java
@@ -157,7 +157,8 @@ final class __PseudoContext__
 	@Override
 	public final int getRemainingTimeInMillis()
 	{
-		throw new Error("TODO");
+		// Just timeout in thirty minutes
+		return 1800000;
 	}
 	
 	/**

--- a/src/main/java/com/iopipe/__PseudoContext__.java
+++ b/src/main/java/com/iopipe/__PseudoContext__.java
@@ -162,8 +162,10 @@ final class __PseudoContext__
 	@Override
 	public final int getRemainingTimeInMillis()
 	{
-		// Just timeout in thirty minutes
-		return 1800000;
+		// Just use zero so 
+		// Some long arbitrary value to signify that it is not valid and it
+		// might not eve time out
+		return Integer.MAX_VALUE;
 	}
 	
 	/**

--- a/src/main/java/com/iopipe/__PseudoContext__.java
+++ b/src/main/java/com/iopipe/__PseudoContext__.java
@@ -15,14 +15,19 @@ import java.util.Objects;
 final class __PseudoContext__
 	implements Context
 {
+	/** The shortened request ID. */
+	protected final int requestid;
+	
 	/**
 	 * Initializes the pseudo context.
 	 *
+	 * @param __in The input object to generate a request ID with, which might
+	 * be unique.
 	 * @since 2018/10/17
 	 */
-	public __PseudoContext__()
+	public __PseudoContext__(Object __in)
 	{
-		throw new Error("TODO");
+		this.requestid = (__in == null ? 0 : __in.hashCode());
 	}
 	
 	/**
@@ -32,7 +37,7 @@ final class __PseudoContext__
 	@Override
 	public final String getAwsRequestId()
 	{
-		throw new Error("TODO");
+		return String.format("%08x", this.requestid);
 	}
 	
 	/**

--- a/src/main/java/com/iopipe/__PseudoContext__.java
+++ b/src/main/java/com/iopipe/__PseudoContext__.java
@@ -89,7 +89,12 @@ final class __PseudoContext__
 	@Override
 	public final String getInvokedFunctionArn()
 	{
-		throw new Error("TODO");
+		// The format is generally in:
+		// arn:partition:service:region:account-id:resourcetype:resource
+		// Note that account-id is unknown from the run-time but it may be
+		// ommitted according to the documentation.
+		return "arn:aws:lambda:" + IOpipeConstants.chosenRegion() +
+			"::function:" + this.getFunctionName();
 	}
 	
 	/**

--- a/src/main/java/com/iopipe/__PseudoContext__.java
+++ b/src/main/java/com/iopipe/__PseudoContext__.java
@@ -1,0 +1,137 @@
+package com.iopipe;
+
+import com.amazonaws.services.lambda.runtime.CognitoIdentity;
+import com.amazonaws.services.lambda.runtime.ClientContext;
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.LambdaLogger;
+
+/**
+ * Pseudo AWS context if one was not specified, this is derived from
+ * environment variables and such.
+ *
+ * @since 2018/10/17
+ */
+final class __PseudoContext__
+	implements Context
+{
+	/**
+	 * Initializes the pseudo context.
+	 *
+	 * @since 2018/10/17
+	 */
+	public __PseudoContext__()
+	{
+		throw new Error("TODO");
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * @since 2018/10/17
+	 */
+	@Override
+	public final String getAwsRequestId()
+	{
+		throw new Error("TODO");
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * @since 2018/10/17
+	 */
+	@Override
+	public final ClientContext getClientContext()
+	{
+		throw new Error("TODO");
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * @since 2018/10/17
+	 */
+	@Override
+	public final String getFunctionName()
+	{
+		throw new Error("TODO");
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * @since 2018/10/17
+	 */
+	@Override
+	public final String getFunctionVersion()
+	{
+		throw new Error("TODO");
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * @since 2018/10/17
+	 */
+	@Override
+	public final CognitoIdentity getIdentity()
+	{
+		throw new Error("TODO");
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * @since 2018/10/17
+	 */
+	@Override
+	public final String getInvokedFunctionArn()
+	{
+		throw new Error("TODO");
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * @since 2018/10/17
+	 */
+	@Override
+	public final LambdaLogger getLogger()
+	{
+		throw new Error("TODO");
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * @since 2018/10/17
+	 */
+	@Override
+	public final String getLogGroupName()
+	{
+		throw new Error("TODO");
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * @since 2018/10/17
+	 */
+	@Override
+	public final String getLogStreamName()
+	{
+		throw new Error("TODO");
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * @since 2018/10/17
+	 */
+	@Override
+	public final int getMemoryLimitInMB()
+	{
+		throw new Error("TODO");
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * @since 2018/10/17
+	 */
+	@Override
+	public final int getRemainingTimeInMillis()
+	{
+		throw new Error("TODO");
+	}
+}
+

--- a/src/test/java/com/iopipe/__DoTimeOut__.java
+++ b/src/test/java/com/iopipe/__DoTimeOut__.java
@@ -124,17 +124,18 @@ class __DoTimeOut__
 			int sleepdur = c.getRemainingTimeInMillis();
 			
 			// Finished sleeping
-			if (sleepdur <= 0)
+			if (sleepdur <= 0 || sleepdur == Integer.MAX_VALUE)
 				break;
 			
 			// Sleep
-			try
-			{
-				Thread.sleep(sleepdur + _EXTRA_SLEEP_TIME);
-			}
-			catch (InterruptedException e)
-			{
-			}
+			if ((sleepdur += _EXTRA_SLEEP_TIME) > 0)
+				try
+				{
+					Thread.sleep(sleepdur);
+				}
+				catch (InterruptedException e)
+				{
+				}
 		}
 		
 		// For for some more to make sure it does actually time out


### PR DESCRIPTION
If a `Context` was not passed to the method it will use one which is derived from environment variables.