### PR TITLE
Add resource based configuration for IOpipe. (Fixes #170, Fixes #169)

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,13 @@ environment variables.
    * Alternative URL for the collector, this is mostly used for debugging and
      experimentation with newer collectors.
 
+Alternatively a configuration may be specified in the root of the JAR with a
+standard properties format (`key=value`) which is named `iopipe.properties`.
+The configuration values are only used if they have not been specified by
+system properties or environment variables. Generally using this is not
+recommended because it would require a redeploy to change the settings. Also
+the token itself is sensitive and should not be placed in the configuration.
+
 IOpipe uses tinylog for its internal logging, to make debug output from IOpipe
 easier to see tinylog can be configured using the following information located
 at:

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ environment variables.
    * If set to `false` then the plugin will be disabled.
    * If this is not set for a plugin then it will use the setting from the
      plugin if it should be enabled by default or not.
- * `IOPIPE_GENERIC_HANDLER`
+ * `com.iopipe.generichandler` or `IOPIPE_GENERIC_HANDLER`
    * This specifies the class (and optionally the method) to be used by the
      generic handler to wrap with IOpipe.
    * `com.example`, implies that the `requestHandler` method be used.

--- a/src/main/java/com/iopipe/IOpipeConfiguration.java
+++ b/src/main/java/com/iopipe/IOpipeConfiguration.java
@@ -143,6 +143,12 @@ public final class IOpipeConfiguration
 		{
 			if (in != null)
 				props.load(in);
+			else
+				try (InputStream intwo = IOpipeConfiguration.class.
+					getResourceAsStream("/iopipe.properties"))
+				{
+					props.load(intwo);
+				}
 		}
 		catch (IOException|SecurityException e)
 		{

--- a/src/main/java/com/iopipe/IOpipeConfiguration.java
+++ b/src/main/java/com/iopipe/IOpipeConfiguration.java
@@ -450,29 +450,27 @@ public final class IOpipeConfiguration
 			// Enabled if not specified is "true" by default
 			boolean enabled;
 			rv.setEnabled((enabled = Boolean.valueOf(Objects.toString(
-				System.getProperty("com.iopipe.enabled",
-				System.getenv("IOPIPE_ENABLED")), "true"))));
+				IOpipeConfiguration.getVariable("com.iopipe.enabled",
+				"IOPIPE_ENABLED", "true")))));
 			
 			// If the configuration is not enabled, then use the disabled one
 			if (!enabled)
 				return IOpipeConfiguration.DISABLED_CONFIG;
 			
 			// Token
-			rv.setProjectToken(System.getProperty("com.iopipe.token",
-				Objects.toString(System.getenv("IOPIPE_TOKEN"),
-					System.getenv("IOPIPE_CLIENTID"))));
+			rv.setProjectToken(IOpipeConfiguration.getVariable("com.iopipe.token",
+				"IOPIPE_TOKEN", System.getenv("IOPIPE_CLIENTID")));
 			
 			// Installation method
-			rv.setInstallMethod(System.getProperty("com.iopipe.installmethod",
-				Objects.toString(System.getenv("IOPIPE_INSTALL_METHOD"),
-				"manual")));
+			rv.setInstallMethod(IOpipeConfiguration.getVariable("com.iopipe.installmethod",
+				"IOPIPE_INSTALL_METHOD", "manual"));
 			
 			// Timeout window
 			try
 			{
 				rv.setTimeOutWindow(Integer.valueOf(Objects.toString(
-					System.getProperty("com.iopipe.timeoutwindow",
-					System.getenv("IOPIPE_TIMEOUT_WINDOW")), "150")));
+					IOpipeConfiguration.getVariable("com.iopipe.timeoutwindow",
+					"IOPIPE_TIMEOUT_WINDOW", "150"))));
 			}
 			catch (NumberFormatException e)
 			{
@@ -481,17 +479,18 @@ public final class IOpipeConfiguration
 			
 			// Go through system properties to get the enabled state of
 			// plugins
-			for (Map.Entry<Object, Object> e : System.getProperties().
-				entrySet())
-			{
-				String k = Objects.toString(e.getKey(), ""),
-					v = Objects.toString(e.getValue(), "");
-				
-				if (k.startsWith(_PROPERTY_PLUGIN_PREFIX))
-					rv.setPluginEnabled(
-						k.substring(_PROPERTY_PLUGIN_PREFIX.length()),
-						Boolean.valueOf(v));
-			}
+			for (int z = 0; z < 2; z++)
+				for (Map.Entry<Object, Object> e : (z == 0 ? System.getProperties() :
+					_PROPERTIES).entrySet())
+				{
+					String k = Objects.toString(e.getKey(), ""),
+						v = Objects.toString(e.getValue(), "");
+					
+					if (k.startsWith(_PROPERTY_PLUGIN_PREFIX))
+						rv.setPluginEnabled(
+							k.substring(_PROPERTY_PLUGIN_PREFIX.length()),
+							Boolean.valueOf(v));
+				}
 			
 			// Go through environment variables to find plugins which are
 			// enabled
@@ -514,9 +513,8 @@ public final class IOpipeConfiguration
 			rv.setRemoteConnectionFactory(new ServiceConnectionFactory());
 			
 			// Setup service URL
-			String surl = System.getProperty("com.iopipe.collectorurl",
-				Objects.toString(System.getenv("IOPIPE_COLLECTOR_URL"),
-					IOpipeConstants.DEFAULT_SERVICE_URL));
+			String surl = IOpipeConfiguration.getVariable("com.iopipe.collectorurl",
+				"IOPIPE_COLLECTOR_URL", IOpipeConstants.DEFAULT_SERVICE_URL);
 			rv.setServiceUrl(surl);
 			Logger.debug("Remote URL: {}", surl);
 			

--- a/src/main/java/com/iopipe/IOpipeConfiguration.java
+++ b/src/main/java/com/iopipe/IOpipeConfiguration.java
@@ -3,6 +3,8 @@ package com.iopipe;
 import com.iopipe.http.NullConnectionFactory;
 import com.iopipe.http.RemoteConnectionFactory;
 import com.iopipe.http.ServiceConnectionFactory;
+import java.io.InputStream;
+import java.io.IOException;
 import java.lang.ref.Reference;
 import java.lang.ref.SoftReference;
 import java.lang.ref.WeakReference;
@@ -86,6 +88,9 @@ public final class IOpipeConfiguration
 	private static final String _ENVIRONMENT_PLUGIN_SUFFIX =
 		"_ENABLED";
 	
+	/** System properties file. */
+	private static final Properties _PROPERTIES;
+	
 	/** The disabled configuration. */
 	public static final IOpipeConfiguration DISABLED_CONFIG;
 	
@@ -131,6 +136,19 @@ public final class IOpipeConfiguration
 	 */
 	static
 	{
+		// Load default properties
+		Properties props = new Properties();
+		try (InputStream in = ClassLoader.getSystemClassLoader().
+			getResourceAsStream("/iopipe.properties"))
+		{
+			if (in != null)
+				props.load(in);
+		}
+		catch (IOException|SecurityException e)
+		{
+		}
+		_PROPERTIES = props;
+		
 		// Initialize disabled configuration
 		IOpipeConfigurationBuilder cb = new IOpipeConfigurationBuilder();
 		

--- a/src/main/java/com/iopipe/IOpipeConfiguration.java
+++ b/src/main/java/com/iopipe/IOpipeConfiguration.java
@@ -529,5 +529,46 @@ public final class IOpipeConfiguration
 			return IOpipeConfiguration.DISABLED_CONFIG;
 		}
 	}
+	
+	/**
+	 * Gets the given variable.
+	 *
+	 * @param __prop The property to read from.
+	 * @param __env The environment variable to check.
+	 * @param __def The default value.
+	 * @return The value from the system property, the environment, or the
+	 * configuration.
+	 * @since 2018/10/31
+	 */
+	public static String getVariable(String __prop, String __env, String __def)
+	{
+		// Check property first
+		String rv;
+		if (__prop != null)
+		{
+			rv = System.getProperty(__prop);
+			if (rv != null)
+				return rv;
+		}
+		
+		// Check environment
+		if (__env != null)
+		{
+			rv = System.getenv(__env);
+			if (rv != null)
+				return rv;
+		}
+		
+		// Check files
+		if (__prop != null)
+		{
+			rv = _PROPERTIES.getProperty(__prop);
+			if (rv != null)
+				return rv;
+		}
+		
+		// Default value
+		return __def;
+	}
 }
 

--- a/src/main/java/com/iopipe/generic/EntryPoint.java
+++ b/src/main/java/com/iopipe/generic/EntryPoint.java
@@ -1,6 +1,7 @@
 package com.iopipe.generic;
 
 import com.amazonaws.services.lambda.runtime.Context;
+import com.iopipe.IOpipeConfiguration;
 import com.iopipe.IOpipeExecution;
 import com.iopipe.IOpipeFatalError;
 import java.io.InputStream;
@@ -223,7 +224,8 @@ public final class EntryPoint
 	public static final EntryPoint defaultAWSEntryPoint()
 	{
 		// This variable is very important
-		String pair = System.getenv("IOPIPE_GENERIC_HANDLER");
+		String pair = IOpipeConfiguration.getVariable("com.iopipe.generichandler",
+			"IOPIPE_GENERIC_HANDLER", null);
 		if (pair == null)
 			throw new InvalidEntryPointException("The environment variable " +
 				"IOPIPE_GENERIC_HANDLER has not been set, execution cannot " +

--- a/src/test/java/com/iopipe/Engine.java
+++ b/src/test/java/com/iopipe/Engine.java
@@ -201,6 +201,7 @@ public abstract class Engine
 			// Logging
 			(__e) -> new __DoLoggerTest__(__e, true),
 			(__e) -> new __DoLoggerTest__(__e, false),
+			__DoConfigFileTest__::new,
 		};
 	
 	/** The base name for this engine. */

--- a/src/test/java/com/iopipe/__DoConfigFileTest__.java
+++ b/src/test/java/com/iopipe/__DoConfigFileTest__.java
@@ -1,0 +1,103 @@
+package com.iopipe;
+
+import com.iopipe.http.RemoteRequest;
+import com.iopipe.http.RemoteResult;
+import com.iopipe.IOpipeConfiguration;
+import java.util.Map;
+import javax.json.JsonString;
+import javax.json.JsonNumber;
+import javax.json.JsonValue;
+
+/**
+ * This performs a test to see if the config file works.
+ *
+ * @since 2018/10/31
+ */
+class __DoConfigFileTest__
+	extends Single
+{
+	/** Sent with no exception? */
+	protected final BooleanValue noerror =
+		new BooleanValue("noerror");
+		
+	/** Got a result from the server okay? */
+	protected final BooleanValue remoterecvokay =
+		new BooleanValue("remoterecvokay");
+	
+	/** Has config option? */
+	protected final BooleanValue hasconfig =
+		new BooleanValue("hasconfig");
+	
+	/** Has missing config option? */
+	protected final BooleanValue hasnoconfig =
+		new BooleanValue("hasnoconfig");
+	
+	/**
+	 * Constructs the test.
+	 *
+	 * @param __e The owning engine.
+	 * @since 2018/10/31
+	 */
+	__DoConfigFileTest__(Engine __e)
+	{
+		super(__e, "configfile");
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * @since 2018/10/31
+	 */
+	@Override
+	public void end()
+	{
+		super.assertTrue(this.remoterecvokay);
+		super.assertTrue(this.noerror);
+		super.assertTrue(this.hasconfig);
+		super.assertTrue(this.hasnoconfig);
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * @since 2018/10/31
+	 */
+	@Override
+	public void remoteRequest(WrappedRequest __r)
+	{
+		StandardPushEvent event = (StandardPushEvent)__r.event;
+		
+		// It is invalid if there is an error
+		if (!event.hasError())
+			this.noerror.set(true);
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * @since 2018/10/31
+	 */
+	@Override
+	public void remoteResult(WrappedResult __r)
+	{
+		if (__Utils__.isResultOkay(__r.result))
+			this.remoterecvokay.set(true);
+	}
+	
+	/**
+	 * {@inheritDoc}
+	 * @since 2018/10/31
+	 */
+	@Override
+	public void run(IOpipeExecution __e)
+		throws Throwable
+	{
+		// Check config
+		if ("squirrel".equals(IOpipeConfiguration.getVariable(
+			"com.iopipe.cutestanimal", "IOPIPE_CUTEST_ANIMAL", "nope")))
+			this.hasconfig.set(true);
+			
+		// Check missing config
+		if ("no!".equals(IOpipeConfiguration.getVariable(
+			"asohdpuiashdpiusdapfiuhdsf", "ASOHDPUIASHDPIUSDAPFIUHDSF", "no!")))
+			this.hasnoconfig.set(true);
+	}
+}
+

--- a/src/test/resources/iopipe.properties
+++ b/src/test/resources/iopipe.properties
@@ -1,0 +1,2 @@
+com.iopipe.cutestanimal = squirrel
+


### PR DESCRIPTION
This will allow for using resources to set IOpipe properties which will have to be included at compile time.