### PR TITLE
Do not directly use a version instead refer to it. (Fixes #198)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Your `pom.xml` file may be modified to include the following dependency:
 <dependency>
   <groupId>com.iopipe</groupId>
   <artifactId>iopipe</artifactId>
-  <version>${com.iopipe.version}</version>
+  <version>${iopipe.version}</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,16 @@ Your `pom.xml` file may be modified to include the following dependency:
 <dependency>
   <groupId>com.iopipe</groupId>
   <artifactId>iopipe</artifactId>
-  <version>1.9.0</version>
+  <version>(replace with latest version of IOpipe)</version>
 </dependency>
 ```
+
+To obtain the latest version you may check it at these locations, the format
+of the version will be `n.n.n`:
+
+ * <https://github.com/iopipe/iopipe-java/releases>
+ * <https://search.maven.org/artifact/com.iopipe/iopipe>
+ * <https://bintray.com/iopipe/iopipe/iopipe/_latestVersion>
 
 It is highly recommended that you use the [Shade Plugin](https://maven.apache.org/plugins/maven-shade-plugin/index.html)
 for Maven since AWS requires that all classes and files are packed into a

--- a/README.md
+++ b/README.md
@@ -42,12 +42,11 @@ Your `pom.xml` file may be modified to include the following dependency:
 <dependency>
   <groupId>com.iopipe</groupId>
   <artifactId>iopipe</artifactId>
-  <version>(replace with latest version of IOpipe)</version>
+  <version>${com.iopipe.version}</version>
 </dependency>
 ```
 
-To obtain the latest version you may check it at these locations, the format
-of the version will be `n.n.n`:
+Find the latest version here (the format of the version will be `n.n.n`):
 
  * <https://github.com/iopipe/iopipe-java/releases>
  * <https://search.maven.org/artifact/com.iopipe/iopipe>


### PR DESCRIPTION
This does not directly use a version so that we do not need to make commits to update the README every time we want to do it.