### PR TITLE
Do not print snooped requests when testing since they may contain binary data. (Fixes #203)

### DIFF
--- a/src/test/java/com/iopipe/__WrappedConnectionFactory__.java
+++ b/src/test/java/com/iopipe/__WrappedConnectionFactory__.java
@@ -115,8 +115,8 @@ final class __WrappedConnectionFactory__
 			throws NullPointerException, RemoteException
 		{
 			// Debug
-			Logger.debug("Snooped request ({}): {}.", __t,
-				__r.bodyAsString());
+			/*Logger.debug("Snooped request ({}): {}.", __t,
+				__r.bodyAsString());*/
 			
 			// Snoop the request being sent to the server to make sure it is
 			// being formed correctly

--- a/src/test/java/com/iopipe/__WrappedConnectionFactory__.java
+++ b/src/test/java/com/iopipe/__WrappedConnectionFactory__.java
@@ -114,10 +114,6 @@ final class __WrappedConnectionFactory__
 		public RemoteResult send(RequestType __t, RemoteRequest __r)
 			throws NullPointerException, RemoteException
 		{
-			// Debug
-			/*Logger.debug("Snooped request ({}): {}.", __t,
-				__r.bodyAsString());*/
-			
 			// Snoop the request being sent to the server to make sure it is
 			// being formed correctly
 			Single single = this.single;


### PR DESCRIPTION
This removes printing the request that was sent to the server in the test code.