### PR TITLE
Remove unused Log4j2 from test build.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -209,18 +209,6 @@
       <version>1.11.22</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <version>2.11.1</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
-      <version>2.11.1</version>
-      <scope>test</scope>
-    </dependency>
 
     <!-- Runtime -->
     <dependency>


### PR DESCRIPTION
This removes the unused log4j2 from the test build.