### PR TITLE
Explicitly set source/target version so JavaDoc 11 does not assume version 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,11 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <showDeprecation>true</showDeprecation>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
         <executions>
           <execution>
             <id>attach-javadocs</id>


### PR DESCRIPTION
When using JavaDoc 11 the build fails because it will assume you are trying to document Java 11 code, so this sets the source/target explicitly to Java 8 so that the build no longer fails.